### PR TITLE
Partial rerendering proof of concept

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -463,7 +463,7 @@ Mithril = m = new function app(window, undefined) {
 		return gettersetter(store)
 	}
 
-	var roots = [], modules = [], controllers = [], lastRedrawId = null, lastRedrawCallTime = 0, computePostRedrawHook = null, prevented = false, topModule
+	var roots = [], modules = [], controllers = [], computePostRedrawHook = null, prevented = false, topModule
 	var FRAME_BUDGET = 16 //60 frames per second = 1 call per 16 ms
 	m.module = function(root, module) {
 		var index = roots.indexOf(root)
@@ -491,26 +491,7 @@ Mithril = m = new function app(window, undefined) {
 			return controllers[index]
 		}
 	}
-	m.redraw = function(force) {
-		var cancel = window.cancelAnimationFrame || window.clearTimeout
-		var defer = window.requestAnimationFrame || window.setTimeout
-		//lastRedrawId is a positive number if a second redraw is requested before the next animation frame
-		//lastRedrawID is null if it's the first redraw and not an event handler
-		if (lastRedrawId && force !== true) {
-			//when setTimeout: only reschedule redraw if time between now and previous redraw is bigger than a frame, otherwise keep currently scheduled timeout
-			//when rAF: always reschedule redraw
-			if (new Date - lastRedrawCallTime > FRAME_BUDGET || defer == window.requestAnimationFrame) {
-				if (lastRedrawId > 0) cancel(lastRedrawId)
-				lastRedrawId = defer(redraw, FRAME_BUDGET)
-			}
-		}
-		else {
-			redraw()
-			lastRedrawId = defer(function() {lastRedrawId = null}, FRAME_BUDGET)
-		}
-	}
-	m.redraw.strategy = m.prop()
-	function redraw() {
+	m.redraw = function() {
 		var mode = m.redraw.strategy()
 		for (var i = 0; i < roots.length; i++) {
 			if (controllers[i] && mode != "none") {
@@ -522,10 +503,9 @@ Mithril = m = new function app(window, undefined) {
 			computePostRedrawHook()
 			computePostRedrawHook = null
 		}
-		lastRedrawId = null
-		lastRedrawCallTime = new Date
 		m.redraw.strategy("diff")
 	}
+	m.redraw.strategy = m.prop()
 
 	var pendingRequests = 0
 	m.startComputation = function() {pendingRequests++}

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -798,44 +798,6 @@ function testMithril(mock) {
 		mock.requestAnimationFrame.$resolve()
 		return valueBefore === "" && root.childNodes[0].nodeValue === "foo"
 	})
-	test(function() {
-		mock.requestAnimationFrame.$resolve() //setup
-		var count = 0
-		var root = mock.document.createElement("div")
-		m.module(root, {
-			controller: function() {},
-			view: function(ctrl) {
-				count++
-			}
-		})
-		mock.requestAnimationFrame.$resolve() //teardown
-		m.redraw() //should run synchronously
-
-		m.redraw() //rest should run asynchronously since they're spamming
-		m.redraw()
-		m.redraw()
-		mock.requestAnimationFrame.$resolve() //teardown
-		return count === 3
-	})
-	test(function() {
-		mock.requestAnimationFrame.$resolve() //setup
-		var count = 0
-		var root = mock.document.createElement("div")
-		m.module(root, {
-			controller: function() {},
-			view: function(ctrl) {
-				count++
-			}
-		})
-		mock.requestAnimationFrame.$resolve() //teardown
-		m.redraw(true) //should run synchronously
-
-		m.redraw(true) //forced to run synchronously
-		m.redraw(true)
-		m.redraw(true)
-		mock.requestAnimationFrame.$resolve() //teardown
-		return count === 5
-	})
 
 	//m.route
 	test(function() {


### PR DESCRIPTION
This is a proof of concept and meant to generate discussion rather than be actually pulled.

This adds a `m.submodule` method. The function definition is a bit different from `m.module` in that the first argument is an already instantiated controller object instance instead of a controller constructor function. It also returns a virtual DOM object as it's meant to be used from view functions.

There is also a `m.redraw.target` prop, which can be set to a falsey value to redraw the entire application or an object like `{ node: domNode, controller: controllerInstance, view: viewFunction }` and during the next redraw, Mithril will call `m.render(target.node, target.view(target.controller))`.

During the DOM `build` process, the closest parent module/submodule is kept track of and any event handlers attached will set `m.redraw.target` appropriately.

Here's a modified todo list, which adds a rendered count to each todo, and lists each todo twice. The top todos are rendered with `m.submodule` and the duplicates are rendered normally. You can add a few todos, and then toggle the checkboxes. You can see toggling the first todos only change the render count of the todo, while the duplicate todos rerender the entire application.

http://plnkr.co/edit/eDt6FAqM3NhNam0AqiQU?p=preview