### PR TITLE
Make code block comments the way closure compiler likes them.

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -18,13 +18,13 @@ var m = (function app(window, undefined) {
 	initialize(window);
 
 
-	/*
+	/**
 	 * @typedef {String} Tag
 	 * A string that looks like -> div.classname#id[param=one][param2=two]
 	 * Which describes a DOM node
 	 */
 
-	/*
+	/**
 	 *
 	 * @param {Tag} The DOM node tag
 	 * @param {Object=[]} optional key-value pairs to be mapped to DOM attrs


### PR DESCRIPTION
Hey!

Just noticed this when I used google closure compiler for a project, for once:
```
mithril.js:21: WARNING - Parse error. Non-JSDoc comment has annotations. Did you mean to start it with '/**'?
	/*
^

mithril.js:27: WARNING - Parse error. Non-JSDoc comment has annotations. Did you mean to start it with '/**'?
	/*
^

0 error(s), 2 warning(s)
```

Seems that simply adding the extra `*` in the comments makes the compiler happy again. So this PR fixes that.

These lines are warnings of course, but seems like a quick win to fix. If the code blocks were formatted like that on purpose, and that this breaks something, please ignore.

#### Steps to reproduce:
```bash
npm i closure-compiler
java -jar node_modules/closure-compiler/lib/vendor/compiler.jar mithril.js > /dev/null
```

#### Result:
See above

#### Expected result:
No output

Thanks again for an awesome project. And happy new year!