### PR TITLE
Adds repository field to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "mithril",
 	"version": "0.1.0",
+    "repository": {
+      "type": "git",
+      "url": "git@github.com:lhorie/mithril.js.git"
+    },
 	"scripts": {
 		"test": "grunt test"
 	},
@@ -11,18 +15,16 @@
 		"grunt-contrib-uglify": "*",
 		"grunt-contrib-clean": "*",
 		"grunt-contrib-concat": "*",
-		"grunt-contrib-watch": "*",
 		"grunt-execute": "*",
 		"grunt-md2html": "*",
 		"grunt-replace": "*",
 		"grunt-contrib-qunit": "*",
-		"grunt-contrib-connect": "*",
 		"grunt-zip": "*",
 
 		"grunt-contrib-connect": "~0.7.1",
 		"grunt-contrib-jshint": "~0.10.0",
 		"grunt-contrib-watch": "~0.6.1",
-		"grunt-jscs-checker": "^0.4.4",
+		"grunt-jscs": "^1.1.0",
 		"grunt-sauce-tunnel": "^0.2.1",
 		"load-grunt-config": "^0.9.2",
 		"merge": "^1.1.3",


### PR DESCRIPTION
Also, fixes name of grunt-jscs. grunt-jscs-checker has been renamed grunt-jscs, and npm was warning about that. Unfortunately, there are no versions of grunt-jscs below 0.6.0, so I upgraded to a current version.

This change does not seem to affect installation or the results of `grunt`.

Also, I removed duplicate keys from package.json.