### PR TITLE
remove script from parentNode since $document.body may have changed

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -874,7 +874,7 @@ var m = (function app(window, undefined) {
 			var script = $document.createElement("script");
 
 			window[callbackKey] = function(resp) {
-				$document.body.removeChild(script);
+				script.parentNode.removeChild(script);
 				options.onload({
 					type: "load",
 					target: {
@@ -885,7 +885,7 @@ var m = (function app(window, undefined) {
 			};
 
 			script.onerror = function(e) {
-				$document.body.removeChild(script);
+				script.parentNode.removeChild(script);
 
 				options.onerror({
 					type: "error",


### PR DESCRIPTION
If rewriting the entire document with m.module it's possible that the body may change before any jsonp callbacks fire.  This PR makes sure to remove the script from the original body.

```
var App = {
  controller: function() {
    this.items = m.request({
      method: 'GET',
      dataType: 'jsonp',
      url: '/items.json',
      initialValue: [],
      background: true
    });
    this.items.then(m.redraw);
  },
  view: function(ctrl) {
    return m('html', [
      m('head'[m('title', 'Items')]),
      m('body', ctrl.items().map(function(item) { m('.item', item)}))
    ]);
  }
};

m.module(document, App);
```