### PR TITLE
README.md is now copied to the output and included for npm publish

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,6 +150,7 @@ module.exports = function(grunt) {
 			comparisons: {expand: true, cwd: inputFolder + "/layout/comparisons/", src: "./**", dest: currentVersionArchiveFolder + "/comparisons/"},
 			unminified: {src: "mithril.js", dest: currentVersionArchiveFolder + "/mithril.js"},
 			minified: {src: "mithril.min.js", dest: currentVersionArchiveFolder + "/mithril.min.js"},
+			readme: {src: "README.md", dest: currentVersionArchiveFolder + "/README.md"},
 			map: {src: "mithril.min.js.map", dest: currentVersionArchiveFolder + "/mithril.min.js.map"},
 			typescript: {src: "mithril.d.ts", dest: currentVersionArchiveFolder + "/mithril.d.ts"},
 			publish: {expand: true, cwd: currentVersionArchiveFolder, src: "./**", dest: outputFolder},

--- a/docs/layout/package.json
+++ b/docs/layout/package.json
@@ -7,5 +7,5 @@
 	"repository": {"type": "git", "url": "https://github.com/lhorie/mithril"},
 	"main": "mithril.js",
 	"licenses": [{"type": "MIT", "url": "http://opensource.org/licenses/MIT"}],
-	"files": ["mithril.min.js", "mithril.min.map", "mithril.js"]
+	"files": ["mithril.min.js", "mithril.min.map", "mithril.js", "README.*"]
 }


### PR DESCRIPTION
Because Mithril looks so lost and forlorn on [npm](https://www.npmjs.com/package/mithril) without a readme.

README.* was added to the files section of the package.json
instead of README.md because a find/replace operation changes
.md to .html