### PR TITLE
Fixed context when calling a module view during redraw.

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -542,7 +542,7 @@ var m = (function app(window, undefined) {
 		var forceRedraw = m.redraw.strategy() === "all";
 		for (var i = 0, root; root = roots[i]; i++) {
 			if (controllers[i]) {
-				m.render(root, (modules[i].view || blank)(controllers[i]), forceRedraw)
+				m.render(root, modules[i].view ? modules[i].view(controllers[i]) : blank(), forceRedraw)
 			}
 		}
 		//after rendering within a routed context, we need to scroll back to the top, and fetch the document title for history.pushState


### PR DESCRIPTION
I had some problems with the Haxe implementation in 0.1.29, and it turned out to be a new call syntax in redraw that caused it. When called as `(modules[i].view || blank)` the context for modules[i].view is lost, and `this` will be `window` in the view function. Calling `modules[i].view` directly fixes it.
