### PR TITLE
fix for #428 introduces new misbehaviour

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -614,6 +614,7 @@ var m = (function app(window, undefined) {
 		}
 		//m.route(route, params)
 		else if (type.call(arguments[0]) === STRING) {
+			var oldRoute = currentRoute;
 			currentRoute = arguments[0];
 			var args = arguments[1] || {}
 			var queryIndex = currentRoute.indexOf("?")
@@ -623,7 +624,7 @@ var m = (function app(window, undefined) {
 			var currentPath = queryIndex > -1 ? currentRoute.slice(0, queryIndex) : currentRoute
 			if (querystring) currentRoute = currentPath + (currentPath.indexOf("?") === -1 ? "?" : "&") + querystring;
 
-			var shouldReplaceHistoryEntry = (arguments.length === 3 ? arguments[2] : arguments[1]) === true || currentRoute === arguments[0];
+			var shouldReplaceHistoryEntry = (arguments.length === 3 ? arguments[2] : arguments[1]) === true || oldRoute === arguments[0];
 
 			if (window.history.pushState) {
 				computePostRedrawHook = function() {


### PR DESCRIPTION
The fix for #428 provided prevents entries beeing written to history. History.back() or hitting browsers back-button don't work anymore, since there are no history entries. 
This is because you are assigning the new path to route to to currentPath and compare these, which always turn out to be equal. Saving the currentPath before the assignment fixes this missbehaviour.