### PR TITLE
added multi argument brackets

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -693,7 +693,7 @@ var m = (function app(window, undefined) {
 			var pair = value != null && (valueType === OBJECT) ?
 				buildQueryString(value, key) :
 				valueType === ARRAY ?
-					value.map(function(item) {return encodeURIComponent(key) + "=" + encodeURIComponent(item)}).join("&") :
+					value.map(function(item) {return encodeURIComponent(key + "[]") + "=" + encodeURIComponent(item)}).join("&") :
 					encodeURIComponent(key) + "=" + encodeURIComponent(value)
 			str.push(pair)
 		}

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -1799,7 +1799,7 @@ function testMithril(mock) {
 	test(function() {
 		var prop = m.request({method: "GET", url: "test", data: {foo: [1, 2]}})
 		mock.XMLHttpRequest.$instances.pop().onreadystatechange()
-		return prop().url === "test?foo=1&foo=2"
+		return prop().url === "test?foo%5B%5D=1&foo%5B%5D=2"
 	})
 
 	// m.request over jsonp


### PR DESCRIPTION
Many servers that support multiple arguments require that the url have  `[]` encode before the equal sign of a query parameter. Since this isn't a standard supported by all servers, I understand if you don't want to accept this change. 