### PR TITLE
m.request: Add XMLHttpRequest parameter to the unwrap method

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -989,7 +989,7 @@ var m = (function app(window, undefined) {
 			try {
 				e = e || event;
 				var unwrap = (e.type === "load" ? xhrOptions.unwrapSuccess : xhrOptions.unwrapError) || identity;
-				var response = unwrap(deserialize(extract(e.target, xhrOptions)));
+				var response = unwrap(deserialize(extract(e.target, xhrOptions)), e.target);
 				if (e.type === "load") {
 					if (type.call(response) === ARRAY && xhrOptions.type) {
 						for (var i = 0; i < response.length; i++) response[i] = new xhrOptions.type(response[i])


### PR DESCRIPTION
Currently, it is close to impossible to read the status code of a response from a server using m.request. With this however, in failure cases, I can create a special wrapping for error cases, adding any detail from header or status code into the response.

This comes as a somewhat opposite of extract where instead we're extracting data from the xhr to deserialize, we are adding data from the xhr to the serialized data. This gives us the power to do something like this:

```javascript
var unwrap = function(data, xhr) {
  return {
    status: xhr.status,
    text: xhr.statusText,
    data: data
  };
};

m.request({method: 'GET', url: apiUrl + path, unwrapError: unwrap });
```

With this, any failed request will have a standard format regardless of the message I get from the server. This is very handy when most servers return only http error codes but can also return messages as well.