### PR TITLE
propify: Fix chaining to return original m.prop

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -723,7 +723,8 @@ var m = (function app(window, undefined) {
 		var prop = m.prop();
 		promise.then(prop);
 		prop.then = function(resolve, reject) {
-			return propify(promise.then(resolve, reject))
+			promise = promise.then(resolve, reject).then(prop);
+			return prop;
 		};
 		return prop
 	}

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -1837,6 +1837,13 @@ function testMithril(mock) {
 		return xhr.$headers["Content-Type"] === undefined
 	})
 	test(function() {
+		var prop = m.request({method: "POST", url: "test", initialValue: "foo"}).then(function(data) { return data; })
+		var initialValue = prop();
+		mock.XMLHttpRequest.$instances.pop().onreadystatechange()
+
+		return initialValue === "foo"
+	})
+	test(function() {
 		var prop = m.request({method: "POST", url: "test", initialValue: "foo"})
 		var initialValue = prop();
 		mock.XMLHttpRequest.$instances.pop().onreadystatechange()


### PR DESCRIPTION
chaining .then() after m.request() will now properly return initialValue if specified.

```javascript
var test = m.request({method: "GET", url: "package.json", background: true, initialValue: "test"}).then(function(d) { return d; });
test(); //will now return 'test' and not undefined.
```