### PR TITLE
Typescript stricter defs

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -2,164 +2,164 @@
 
 interface MithrilStatic {
 
-       (selector: string, attributes: MithrilAttributes, ...children: Array<string|MithrilVirtualElement>): MithrilVirtualElement;
-       (selector: string, ...children: Array<string|MithrilVirtualElement>): MithrilVirtualElement;
+    (selector: string, attributes: MithrilAttributes, ...children: Array<string|MithrilVirtualElement>): MithrilVirtualElement;
+    (selector: string, ...children: Array<string|MithrilVirtualElement>): MithrilVirtualElement;
 
-       prop<T>(promise: MithrilPromise<T>) : MithrilPromiseProperty<T>;
-       prop<T>(value: T): MithrilProperty<T>;
-       prop(): MithrilProperty<Object>; // might be that this should be Property<any>
+    prop<T>(promise: MithrilPromise<T>) : MithrilPromiseProperty<T>;
+    prop<T>(value: T): MithrilProperty<T>;
+    prop(): MithrilProperty<Object>; // might be that this should be Property<any>
 
-       withAttr(property: string, callback: (value: any) => void): (e: MithrilEvent) => any;
+    withAttr(property: string, callback: (value: any) => void): (e: MithrilEvent) => any;
 
-       module<T extends MithrilController>(rootElement: Node, module: MithrilModule<T>): T;
-       module<T extends MithrilController>(rootElement: Node): T;
+    module<T extends MithrilController>(rootElement: Node, module: MithrilModule<T>): T;
+    module<T extends MithrilController>(rootElement: Node): T;
 
-       trust(html: string): string;
+    trust(html: string): string;
 
-       render(rootElement: Element|HTMLDocument): void;
-       render(rootElement: Element|HTMLDocument, children: MithrilVirtualElement, forceRecreation?: boolean): void;
-       render(rootElement: Element|HTMLDocument, children: MithrilVirtualElement[], forceRecreation?: boolean): void;
+    render(rootElement: Element|HTMLDocument): void;
+    render(rootElement: Element|HTMLDocument, children: MithrilVirtualElement, forceRecreation?: boolean): void;
+    render(rootElement: Element|HTMLDocument, children: MithrilVirtualElement[], forceRecreation?: boolean): void;
 
-       redraw: {
-              (force?: boolean): void;
-              strategy: MithrilProperty<string>;
-       }
+    redraw: {
+        (force?: boolean): void;
+        strategy: MithrilProperty<string>;
+    }
 
-       route: {
-              <T extends MithrilController>(rootElement: HTMLDocument, defaultRoute: string, routes: MithrilRoutes<T>): void;
-              <T extends MithrilController>(rootElement: Element, defaultRoute: string, routes: MithrilRoutes<T>): void;
+    route: {
+        <T extends MithrilController>(rootElement: HTMLDocument, defaultRoute: string, routes: MithrilRoutes<T>): void;
+        <T extends MithrilController>(rootElement: Element, defaultRoute: string, routes: MithrilRoutes<T>): void;
 
-              (element: Element, isInitialized: boolean): void;
-              (path: string, params?: any, shouldReplaceHistory?: boolean): void;
-              (): string;
+        (element: Element, isInitialized: boolean): void;
+        (path: string, params?: any, shouldReplaceHistory?: boolean): void;
+        (): string;
 
-              param(key: string): string;
-              mode: string;
-       }
+        param(key: string): string;
+        mode: string;
+    }
 
-       request<T>(options: MithrilXHROptions): MithrilPromise<T>;
+    request<T>(options: MithrilXHROptions): MithrilPromise<T>;
 
-       deferred: {
-              onerror(e: Error): void;
-              <T>(): MithrilDeferred<T>;
-       }
+    deferred: {
+        onerror(e: Error): void;
+        <T>(): MithrilDeferred<T>;
+    }
 
-       sync<T>(promises: MithrilPromise<T>[]): MithrilPromise<T[]>;
+    sync<T>(promises: MithrilPromise<T>[]): MithrilPromise<T[]>;
 
-       startComputation(): void;
-       endComputation(): void;
+    startComputation(): void;
+    endComputation(): void;
 
-       // For test suite
-       deps: {
-              (mockWindow: Window): Window;
-              factory: Object;
-       }
+    // For test suite
+    deps: {
+        (mockWindow: Window): Window;
+        factory: Object;
+    }
 
 }
 
 interface MithrilVirtualElement {
-       key?: number;
-       tag?: string;
-       attrs?: MithrilAttributes;
-       children?: any[];
+    key?: number;
+    tag?: string;
+    attrs?: MithrilAttributes;
+    children?: any[];
 }
 
 // Configuration function for an element
 interface MithrilElementConfig {
-       (element: Element, isInitialized: boolean, context?: any): void;
+    (element: Element, isInitialized: boolean, context?: any): void;
 }
 
 // Attributes on a virtual element
 interface MithrilAttributes {
-       title?: string;
-       className?: string;
-       class?: string;
-       config?: MithrilElementConfig;
+    title?: string;
+    className?: string;
+    class?: string;
+    config?: MithrilElementConfig;
 }
 
 // Defines the subset of Event that Mithril needs
 interface MithrilEvent {
-       currentTarget: Element;
+    currentTarget: Element;
 }
 
 interface MithrilController {
-       onunload?(evt: Event): any;
+    onunload?(evt: Event): any;
 }
 
 interface MithrilControllerFunction extends MithrilController {
-       (): any;
+    (): any;
 }
 
 interface MithrilView<T extends MithrilController> {
-       (ctrl: T): string|MithrilVirtualElement;
+    (ctrl: T): string|MithrilVirtualElement;
 }
 
 interface MithrilModule<T extends MithrilController> {
-       controller: MithrilControllerFunction|{ new(): T };
-       view: MithrilView<T>;
+    controller: MithrilControllerFunction|{ new(): T };
+    view: MithrilView<T>;
 }
 
 interface MithrilProperty<T> {
-       (): T;
-       (value: T): T;
-       toJSON(): T;
+    (): T;
+    (value: T): T;
+    toJSON(): T;
 }
 
 interface MithrilPromiseProperty<T> extends MithrilPromise<T> {
-       (): T;
-       (value: T): T;
-       toJSON(): T;
+    (): T;
+    (value: T): T;
+    toJSON(): T;
 }
 
 interface MithrilRoutes<T extends MithrilController> {
-       [key: string]: MithrilModule<T>;
+    [key: string]: MithrilModule<T>;
 }
 
 
 interface MithrilDeferred<T> {
-       resolve(value?: T): void;
-       reject(value?: any): void;
-       promise: MithrilPromise<T>;
+    resolve(value?: T): void;
+    reject(value?: any): void;
+    promise: MithrilPromise<T>;
 }
 
 interface MithrilSuccessCallback<T, U> {
-       (value: T): U;
-       (value: T): MithrilPromise<U>;
+    (value: T): U;
+    (value: T): MithrilPromise<U>;
 }
 
 interface MithrilErrorCallback<U> {
-       (value: Error): U;
-       (value: string): U;
+    (value: Error): U;
+    (value: string): U;
 }
 
 interface MithrilPromise<T> {
-       (): T;
-       (value: T): T;
-       then<U>(success: (value: T) => U): MithrilPromise<U>;
-       then<U>(success: (value: T) => MithrilPromise<U>): MithrilPromise<U>;
-       then<U,V>(success: (value: T) => U, error: (value: Error) => V): MithrilPromise<U>|MithrilPromise<V>;
-       then<U,V>(success: (value: T) => MithrilPromise<U>, error: (value: Error) => V): MithrilPromise<U>|MithrilPromise<V>;
+    (): T;
+    (value: T): T;
+    then<U>(success: (value: T) => U): MithrilPromise<U>;
+    then<U>(success: (value: T) => MithrilPromise<U>): MithrilPromise<U>;
+    then<U,V>(success: (value: T) => U, error: (value: Error) => V): MithrilPromise<U>|MithrilPromise<V>;
+    then<U,V>(success: (value: T) => MithrilPromise<U>, error: (value: Error) => V): MithrilPromise<U>|MithrilPromise<V>;
 }
 interface MithrilXHROptions {
-       method?: string;
-       url: string;
-       user?: string;
-       password?: string;
-       data?: any;
-       background?: boolean;
-       unwrapSuccess?(data: any): any;
-       unwrapError?(data: any): any;
-       serialize?(dataToSerialize: any): string;
-       deserialize?(dataToDeserialize: string): any;
-       extract?(xhr: XMLHttpRequest, options: MithrilXHROptions): string;
-       type?(data: Object): void;
-       config?(xhr: XMLHttpRequest, options: MithrilXHROptions): XMLHttpRequest;
-       dataType?: string;
+    method?: string;
+    url: string;
+    user?: string;
+    password?: string;
+    data?: any;
+    background?: boolean;
+    unwrapSuccess?(data: any): any;
+    unwrapError?(data: any): any;
+    serialize?(dataToSerialize: any): string;
+    deserialize?(dataToDeserialize: string): any;
+    extract?(xhr: XMLHttpRequest, options: MithrilXHROptions): string;
+    type?(data: Object): void;
+    config?(xhr: XMLHttpRequest, options: MithrilXHROptions): XMLHttpRequest;
+    dataType?: string;
 }
 
 declare var Mithril: MithrilStatic;
 declare var m: MithrilStatic;
 
 declare module 'mithril' {
-       export = m;
+    export = m;
 }

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -83,8 +83,11 @@ interface MithrilEvent {
 }
 
 interface MithrilController {
-       (): any;
        onunload?(evt: Event): any;
+}
+
+interface MithrilControllerFunction extends MithrilController {
+       (): any;
 }
 
 interface MithrilView<T extends MithrilController> {
@@ -92,7 +95,7 @@ interface MithrilView<T extends MithrilController> {
 }
 
 interface MithrilModule<T extends MithrilController> {
-       controller: T;
+       controller: MithrilControllerFunction|{ new(): T };
        view: MithrilView<T>;
 }
 


### PR DESCRIPTION
A small addition to the previous PR, with two changes:
- making it possible to also use TypeScript classes as controllers
- making indentation of .d.ts consistent with mithril.js (was 7 spaces, now 4)

Tests and demos are [here again](https://github.com/cbowdon/HeavyMithril). As always, let me know if you want me to make any changes and I'll be happy to.