### PR TITLE
added parsing of '?' for query strings

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -734,7 +734,12 @@ var m = (function app(window, undefined) {
 		return str.join("&")
 	}
 	function parseQueryString(str) {
-		var pairs = str.split("&"), params = {};
+		if (str[0] === "?") {
+			str = str.substring(1);
+		}
+
+		var pairs = str.split("&"), 
+			params = {};
 		for (var i = 0, len = pairs.length; i < len; i++) {
 			var pair = pairs[i].split("=");
 			var key = decodeURIComponent(pair[0])


### PR DESCRIPTION
The `m.route.parseQueryString` method doesn't not correctly account for a `?` in a string, which is returned when calling `window.location.search`. It seems that Mithril should take this into account. 