### PR TITLE
Fix module.exports

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1139,5 +1139,5 @@ var m = (function app(window, undefined) {
 	return m
 })(typeof window != "undefined" ? window : {});
 
-if (typeof component != "undefined" && component !== null && component.exports) component.exports = m;
+if (typeof module != "undefined" && module !== null && module.exports) module.exports = m;
 else if (typeof define === "function" && define.amd) define(function() {return m});


### PR DESCRIPTION
Looks like you did a mass find/replace of ‘module’ to ‘component’,
accidentally breaking module.exports