### PR TITLE
Fix onunload being called with incorrect context

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -568,7 +568,7 @@ var m = (function app(window, undefined) {
 		var isPrevented = false;
 		var event = {preventDefault: function() {isPrevented = true}};
 		for (var i = 0, unloader; unloader = unloaders[i]; i++) {
-			unloader.handler(event)
+			unloader.handler.call(unloader.controller, event)
 			unloader.controller.onunload = null
 		}
 		if (isPrevented) {


### PR DESCRIPTION
onunload functions collected from components in `build()` weren't being called with the controller as their context.

```javascript
myComponent.controller = function() {
  this.foo = 'bar';
  this.onunload = function() {
    console.log(this.foo); // expected: bar, actual: undefined
  }
}
```
