### PR TITLE
Canonicalize `options.method` in m.request

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1027,6 +1027,7 @@ var m = (function app(window, undefined) {
 		var extract = xhrOptions.extract || function(xhr) {
 			return xhr.responseText.length === 0 && deserialize === JSON.parse ? null : xhr.responseText
 		};
+		xhrOptions.method = (xhrOptions.method || 'GET').toUpperCase();
 		xhrOptions.url = parameterizeUrl(xhrOptions.url, xhrOptions.data);
 		xhrOptions = bindData(xhrOptions, xhrOptions.data, serialize);
 		xhrOptions.onload = xhrOptions.onerror = function(e) {


### PR DESCRIPTION
Currently, `m.request({ method: 'get', data: foo, url: bar })` doesn't send the data to the server because the method is checked against uppercase `"GET"`. The documentation does say the 'method must be either `"GET"`, `"POST"`, ...', but it wasn't immediately obvious why it didn't work because HTTP methods are usually treated case-insensitively.