### PR TITLE
Install grunt explicitly to stop warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"main": "mithril.js",
 	"devDependencies": {
+		"grunt": "*",
 		"grunt-cli": "*",
 		"grunt-contrib-copy": "*",
 		"grunt-contrib-uglify": "*",


### PR DESCRIPTION
I added grunt as a devDependency to stop the many warnings like this

```
npm WARN peerDependencies The peer dependency grunt@~0.4.0 included from grunt-md2html will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

seen on `npm install`.