### PR TITLE
Update `Rendering before web service requests finish` code sample

### DIFF
--- a/docs/mithril.request.md
+++ b/docs/mithril.request.md
@@ -394,12 +394,17 @@ However, sometimes we do want to be able to redraw before a web service request 
 Setting the `background` option to `true` prevents a request from affecting redrawing. This means it's possible for a view to attempt to use data before it is available. You can specify an initial value for the `m.request` getter-setter in order to avoid having to write defensive code against potential null reference exceptions:
 
 ```javascript
+var getUsers = function() {
+	return m.request({method: "GET", url: "/api/user", background: true, initialValue: []})
+}
+
 var demo = {}
 
 demo.controller = function() {
-	return {
-		users: m.request({method: "GET", url: "/api/user", background: true, initialValue: []})
-	}
+	this.users = getUsers().then(function (users) {
+		this.users = m.prop(users)
+		m.redraw()
+	}.bind(this))
 }
 
 //in the view


### PR DESCRIPTION
Following the code sample, the fetched data is not rendered: http://jsfiddle.net/alyssaq/f74re4g2
With this update, the data is rendered: http://jsfiddle.net/alyssaq/f74re4g2/7/