### PR TITLE
Avoid EOL diff horror by enforcing CRLF on commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=crlf


### PR DESCRIPTION
Let's not have PRs like this ever again: https://github.com/lhorie/mithril.js/compare/components...barneycarroll:3f3812917a035532c0cba268922bbf7dfc0e6d61