### PR TITLE
check for {subtree:"retain"} AFTER call to view() to abort diffing

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -99,7 +99,6 @@ var m = (function app(window, undefined) {
 		//- it simplifies diffing code
 		//data.toString() might throw or return null if data is the return value of Console.log in Firefox (behavior depends on version)
 		try {if (data == null || data.toString() == null) data = "";} catch (e) {data = ""}
-		if (data.subtree === "retain") return cached;
 		var cachedType = type.call(cached), dataType = type.call(data);
 		if (cached == null || cachedType !== dataType) {
 			if (cached != null) {
@@ -246,6 +245,7 @@ var m = (function app(window, undefined) {
 				var controller = controllerIndex > -1 ? cached.controllers[controllerIndex] : new (data.controller || noop)
 				var key = data && data.attrs && data.attrs.key
 				data = pendingRequests == 0 || (cached && cached.controllers && cached.controllers.indexOf(controller) > -1) ? data.view(controller) : {tag: "placeholder"}
+                                if (data.subtree === "retain") return cached;
 				if (key) {
 					if (!data.attrs) data.attrs = {}
 					data.attrs.key = key


### PR DESCRIPTION
We want to abort diffing at a particular node but we can't receive that signal until after view() is called.
Currently the "retain" check occurs before the `{subtree:"retain"}` object is discovered via view().
It's unnecessary to let build() catch the "retain" on the next iteration when build() can return "cached" immediately upon discovery.

Shamefully I have not written tests for this, but I have anecdotally mixed and matched Components and Subcomponents, descendants and siblings, with different virtual elements marked "retain", using current-time markers. In all my test cases the right component(s) get diffed. A cached node that is only a string does not cause an error. And a component whose root node is a `{subtree:"retain"}` aborts the diff as well.

I did not test dynamic insertion of new components/subcomponents or their replacement. I'd expect inserting a new component or replacing one component for another that is the descendant of a subtree:retain might be a problem.  I presume `m.redraw.strategy('all')` would remedy that case. (or would it...?)

I hope I'm not missing the point, here.