### PR TITLE
Fixing TS1016: A required parameter cannot follow an optional parameter

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -68,7 +68,7 @@ declare module _mithril {
 
 	// Configuration function for an element
 	interface MithrilElementConfig {
-		(element: Element, isInitialized: boolean, context?: any, vdom: MithrilVirtualElement): void;
+		(element: Element, isInitialized: boolean, context?: any, vdom?: MithrilVirtualElement): void;
 	}
 
 	// Attributes on a virtual element


### PR DESCRIPTION
Fixing a typescript compile error.