### PR TITLE
Support nested selectors in m() calls

### DIFF
--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -64,6 +64,32 @@ function testMithril(mock) {
 		return c1.args === args && c1.args == c2.args
 	})
 
+
+	//nested selectors
+	test(function() {
+		var v1 = m("div.x > span", { class: "y" })
+		var v2 = v1.children[0]
+		return v1.tag === "div" && v1.attrs.className == "x" &&
+					 v2.tag === "span" && v2.attrs.class == "y"
+	})
+	test(function() {
+		// Gracefully handle any number of spaces
+		var v1 = m(".form-group  >.inner>label",
+			"Full Name:",
+			m("input[type=text]")
+		)
+		var inner = v1.children[0]
+		var label = v1.children[0].children[0]
+		var text  = v1.children[0].children[0].children[0]
+		var input = v1.children[0].children[0].children[1]
+
+		return v1.tag === "div" && v1.attrs.className === "form-group" &&
+		       inner.tag === "div" && inner.attrs.className === "inner" &&
+		       label.tag === "label" &&
+		       text      === "Full Name:" &&
+		       input.tag === "input" && input.attrs.type === "text"
+	})
+
 	//m.mount
 	test(function() {
 		var root = mock.document.createElement("div")


### PR DESCRIPTION
Use case: I am currently in the process of converting an Angular + Foundation project over to Mithril. CSS frameworks like Foundation and Bootstrap make extensive use of elements with classes that have no other purpose than styling.

Normally this would cause Mithril views to look convoluted, but I've found a solution to be particularly elegant: nested selectors in m() calls.

Here are some real code snippet use cases taken from my project. The `m.x` you see is a view wrapper as described in the [extending the view language article](http://lhorie.github.io/mithril-blog/extending-the-view-language.html):

```javascript
// Simple example
m.x('.form-group > label', [ // nested
  "Currency",
  m.x('select', { bindValue: form.currency }, ctrl.currencyOptions),
]),

// Complex example
m.x('.form-group.row > .medium-5.columns', [ // nested
  m.x('label > span', [ // nested
    "Minimum Donation Amount ",

    // double nested!
    m.x('.row.row-amount > .medium-5.amount-field.column > .input-group.clearfix', [
      m('span.input-group-addon', currencySymbol),
      m.x('input[type=text][maxlength=3]', { bindValue: form.min_amt })
    ])
  ])
]),
```

As you can see, this makes using css frameworks like Foundation quite palatable. It's also a strong argument for using JavaScript as a view template language.

The changes in this PR support this feature. Let me know what you think.

**Edit:** Updated example to use new changes in PR