### PR TITLE
accept component as first argument to m()

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -34,6 +34,7 @@ var m = (function app(window, undefined) {
 	 */
 	function m() {
 		var args = [].slice.call(arguments);
+		if (type.call(args[0]) == OBJECT) return parameterize(args[0], args.slice(1));
 		var hasAttrs = args[1] != null && type.call(args[1]) === OBJECT && !("tag" in args[1] || "view" in args[1]) && !("subtree" in args[1]);
 		var attrs = hasAttrs ? args[1] : {};
 		var classAttrName = "class" in attrs ? "class" : "className";

--- a/mithril.js
+++ b/mithril.js
@@ -34,7 +34,7 @@ var m = (function app(window, undefined) {
 	 */
 	function m() {
 		var args = [].slice.call(arguments);
-		if (type.call(args[0]) == OBJECT) return parameterize(args[0], args.slice(1));
+		if (type.call(args[0]) === OBJECT) return parameterize(args[0], args.slice(1));
 		var hasAttrs = args[1] != null && type.call(args[1]) === OBJECT && !("tag" in args[1] || "view" in args[1]) && !("subtree" in args[1]);
 		var attrs = hasAttrs ? args[1] : {};
 		var classAttrName = "class" in attrs ? "class" : "className";

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -47,7 +47,23 @@ function testMithril(mock) {
 		var v2 = m(".foo", {class: "bar", onclick: function() {}})
 		return Object.keys(v1.attrs).join() === Object.keys(v2.attrs).join()
 	})
-	
+	test(function() {
+		//m should proxy object first arg to m.component
+		var component = {
+			controller: function(args) {
+				this.args = args
+			},
+			view: function(ctrl) {
+				return m("div", "testing")
+			}
+		}
+		var args = {age: 12}
+		var c1 = m(component, args).controller()
+		var c2 = m.component(component, args).controller()
+
+		return c1.args === args && c1.args == c2.args
+	})
+
 	//m.mount
 	test(function() {
 		var root = mock.document.createElement("div")


### PR DESCRIPTION
This is the suggested diff from #632 for allowing component as the first argument to `m()` for interop with babel's `jsxPragma`.