### PR TITLE
(docs) fixed bower description

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,7 +60,7 @@ Then, to use Mithril, point a script tag to the downloaded file:
 
 ### Bower
 
-[Bower](http://bower.io) is a package manager for [NodeJS](http://nodejs.org/). If you're using NodeJS already or planning on using [Grunt](http://gruntjs.com/) to create a build system, you can use Bower to conveniently keep up-to-date with Mithril versions.
+[Bower](http://bower.io) is a frontend package manager built in [NodeJS](http://nodejs.org/). If you're using NodeJS already or planning on using [Grunt](http://gruntjs.com/) to create a build system, you can use Bower to conveniently keep up-to-date with Mithril versions.
 
 Assuming you have NodeJS installed, you can install Bower by typing this in the command line:
 


### PR DESCRIPTION
Technically, Bower isn't really a package manager for Node.js, but rather, it's made in Node and built for usage in the frontend, hence why many popular frontend libraries, such as JQuery or Bootstrap have their distributions on there. Bower also has its own package repositories.