### PR TITLE
Add ability to redraw a single component.

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -254,6 +254,16 @@ var m = (function app(window, undefined) {
 				}
 				if (controller.onunload) unloaders.push({controller: controller, handler: controller.onunload})
 				views.push(view)
+        //FIX for REDRAW
+        if (controller.redrawSelf) {
+          controller.redrawSelf = (function(ctrl) {
+            return function() {
+              m.redraw.strategy('none');
+              var newData = view(ctrl)
+              build(parentElement, parentTag, parentCache, parentIndex, newData, cached, shouldReattach, index, editable, namespace, configs);
+            }
+          })(controller);
+        }
 				controllers.push(controller)
 			}
 			if (!data.tag && controllers.length) throw new Error("Component template must return a virtual element, not an array, string, etc.")
@@ -964,7 +974,7 @@ var m = (function app(window, undefined) {
 					if (state === RESOLVING && typeof successCallback === FUNCTION) {
 						promiseValue = successCallback(promiseValue)
 					}
-					else if (state === REJECTING && typeof failureCallback === FUNCTION) {
+					else if (state === REJECTING && typeof failureCallback === "function") {
 						promiseValue = failureCallback(promiseValue);
 						state = RESOLVING
 					}
@@ -1161,3 +1171,4 @@ var m = (function app(window, undefined) {
 
 if (typeof module != "undefined" && module !== null && module.exports) module.exports = m;
 else if (typeof define === "function" && define.amd) define(function() {return m});
+


### PR DESCRIPTION
Motivation and additional explanation for this feature can be found here: 

https://groups.google.com/forum/#!topic/mithriljs/P-i3NDIR0eo

TLDR: This allows a single component to prevent a global redraw check, but still redraw itself.  Useful for optimizing performance when you know an event affects only the component from which it originates.

NOTE: This pull request uses the simpler API described in [this post](https://groups.google.com/d/msg/mithriljs/P-i3NDIR0eo/2Pup9DhmpHIJ), so please refer to that example rather than the one in the thread's OP.