### PR TITLE
prevent frozen redraw state on application error

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -614,21 +614,23 @@ var m = (function app(window, undefined) {
 	m.redraw = function(force) {
 		if (redrawing) return
 		redrawing = true
-		if (force) forcing = true
-		//lastRedrawId is a positive number if a second redraw is requested before the next animation frame
-		//lastRedrawID is null if it's the first redraw and not an event handler
-		if (lastRedrawId && force !== true) {
-			//when setTimeout: only reschedule redraw if time between now and previous redraw is bigger than a frame, otherwise keep currently scheduled timeout
-			//when rAF: always reschedule redraw
-			if ($requestAnimationFrame === window.requestAnimationFrame || new Date - lastRedrawCallTime > FRAME_BUDGET) {
-				if (lastRedrawId > 0) $cancelAnimationFrame(lastRedrawId);
-				lastRedrawId = $requestAnimationFrame(redraw, FRAME_BUDGET)
+		try {
+			if (force) forcing = true
+			//lastRedrawId is a positive number if a second redraw is requested before the next animation frame
+			//lastRedrawID is null if it's the first redraw and not an event handler
+			if (lastRedrawId && force !== true) {
+				//when setTimeout: only reschedule redraw if time between now and previous redraw is bigger than a frame, otherwise keep currently scheduled timeout
+				//when rAF: always reschedule redraw
+				if ($requestAnimationFrame === window.requestAnimationFrame || new Date - lastRedrawCallTime > FRAME_BUDGET) {
+					if (lastRedrawId > 0) $cancelAnimationFrame(lastRedrawId);
+					lastRedrawId = $requestAnimationFrame(redraw, FRAME_BUDGET)
+				}
 			}
-		}
-		else {
-			redraw();
-			lastRedrawId = $requestAnimationFrame(function() {lastRedrawId = null}, FRAME_BUDGET)
-		}
+			else {
+				redraw();
+				lastRedrawId = $requestAnimationFrame(function () {lastRedrawId = null}, FRAME_BUDGET)
+			}
+		} catch(e) { redrawing = forcing = false; throw e; }
 		redrawing = forcing = false
 	};
 	m.redraw.strategy = m.prop();


### PR DESCRIPTION
view this diff ignoring whitespace by adding this query string `?w=`
https://github.com/lhorie/mithril.js/compare/next...sjungwirth:next?w=1

This change is to prevent the frozen state where redraws will no longer happen in the case when an application error is encountered while redrawing. This can happen due to bad API responses or simply sloppy code, but it shouldn't result in the shutdown of the application.

Example: 
A mobile user loses connectivity and is unable to reach the API to get data for the next view. Currently this can easily result in unexpected data in the view  which causes an exception such as `Uncaught TypeError: Cannot read property 'id' of undefined`. At least let the user try again after restoring connection, or performing other offline actions, instead of permanently freezing the redrawing engine.