### PR TITLE
Add presense checking for 'url' in 'm.request'

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1129,6 +1129,7 @@ var m = (function app(window, undefined) {
 			return xhr.responseText.length === 0 && deserialize === JSON.parse ? null : xhr.responseText;
 		};
 		xhrOptions.method = (xhrOptions.method || 'GET').toUpperCase();
+		if (!xhrOptions.url) throw new Error("url is a required parameter in `m.request`.");
 		xhrOptions.url = parameterizeUrl(xhrOptions.url, xhrOptions.data);
 		xhrOptions = bindData(xhrOptions, xhrOptions.data, serialize);
 		xhrOptions.onload = xhrOptions.onerror = function(e) {


### PR DESCRIPTION
(Minor issue)
If a sleep-deprived user accustomed to [request](https://github.com/request/request)'s options calls m.request with "uri" instead of "url", JavaScript will obtusely tell him that "undefined has no method match" in the first line of parametrizeUrl. it probably would be better to inform him earlier of his mistake (and thus spare him a few hours of debugging). 