### PR TITLE
Don't pass value/reason to promise.finally callback.

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1056,11 +1056,11 @@ var m = (function app(window, undefined) {
 		};
 		prop["catch"] = prop.then.bind(null, null);
 		prop["finally"] = function(callback) {
-			var _callback = function(value) {return m.deferred().resolve(callback(value)).promise;};
+			var _callback = function() {return m.deferred().resolve(callback()).promise;};
 			return prop.then(function(value) {
-				return propify(_callback(value).then(function() {return value;}), initialValue);
+				return propify(_callback().then(function() {return value;}), initialValue);
 			}, function(reason) {
-				return propify(_callback(reason).then(function() {throw new Error(reason);}), initialValue);
+				return propify(_callback().then(function() {throw new Error(reason);}), initialValue);
 			});
 		};
 		return prop;

--- a/mithril.js
+++ b/mithril.js
@@ -1055,8 +1055,8 @@ var m = (function app(window, undefined) {
 			return propify(promise.then(resolve, reject), initialValue);
 		};
 		prop["catch"] = prop.then.bind(null, null);
-		prop["finally"] = function(callback){
-			var _callback = function(value){return m.deferred().resolve(callback(value)).promise;};
+		prop["finally"] = function(callback) {
+			var _callback = function(value) {return m.deferred().resolve(callback(value)).promise;};
 			return prop.then(function(value) {
 				return propify(_callback(value).then(function() {return value;}), initialValue);
 			}, function(reason) {

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -3916,11 +3916,11 @@ function testMithril(mock) {
 		return prop().message === "error occurred" && error().message === "error occurred"
 	})
 	test(function() {
-		// Data returned by then() functions propagate to finally().
+		// Data returned by then() functions do *not* propagate to finally().
 		var data = m.prop("");
 		var prop = m.request({method: "GET", url: "test"}).then(function() {return "foo"})["finally"](data)
 		mock.XMLHttpRequest.$instances.pop().onreadystatechange()
-		return prop() === "foo" && data() === "foo"
+		return prop() === "foo" && data() === ""
 	})
 	test(function() {
 		// Data returned by finally() functions do *not* propagate to next promise.


### PR DESCRIPTION
This behavior is inline with ES6.

Refs #680 