### PR TITLE
#745 Remove references to DOM nodes when unmounting (Follow-up to #727)

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -764,6 +764,8 @@ var m = (function app(window, undefined) {
 			controllers[index].onunload(event);
 		}
 
+		var isNullComponent = component === null;
+
 		if (!isPrevented) {
 			m.redraw.strategy("all");
 			m.startComputation();
@@ -777,14 +779,24 @@ var m = (function app(window, undefined) {
 				components[index] = component;
 			}
 			endFirstComputation();
+			if (isNullComponent) {
+				removeRootElement(root, index);
+			}
 			return controllers[index];
 		}
-		if (!component) {
-			roots.splice(index, 1);
-			controllers.splice(index, 1);
-			components.splice(index, 1);
+		if (isNullComponent) {
+			removeRootElement(root, index);
 		}
 	};
+
+	function removeRootElement(root, index) {
+		roots.splice(index, 1);
+		controllers.splice(index, 1);
+		components.splice(index, 1);
+		reset(root);
+		nodeCache.splice(getCellCacheKey(root), 1);
+	}
+
 	var redrawing = false, forcing = false;
 	m.redraw = function(force) {
 		if (redrawing) return;


### PR DESCRIPTION
Unfortunately, the fix for #727 did not fix the issue. The code need to also be placed inside the !isPrevented block. Also references in nodeCache cellCache needed to be cleared.
