### PR TITLE
allow m.withAttr callback to determine its own `this` [non-breaking]

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -851,11 +851,12 @@ var m = (function app(window, undefined) {
 		else m.endComputation();
 	}
 
-	m.withAttr = function(prop, withAttrCallback) {
+	m.withAttr = function(prop, withAttrCallback, callbackThis) {
 		return function(e) {
 			e = e || event;
 			var currentTarget = e.currentTarget || this;
-			withAttrCallback(prop in currentTarget ? currentTarget[prop] : currentTarget.getAttribute(prop));
+			var _this = callbackThis || this;
+			withAttrCallback.call(_this, prop in currentTarget ? currentTarget[prop] : currentTarget.getAttribute(prop));
 		};
 	};
 

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -1380,6 +1380,13 @@ function testMithril(mock) {
 		handler({currentTarget: {test: "foo"}})
 		return value === "foo"
 	})
+	test(function() {
+		var value
+		var _this
+		var handler = m.withAttr("test", function(data) {value = data}, _this)
+		handler({currentTarget: {test: "foo"}})
+		return value === "foo" && handler.this === _this
+	})
 
 	//m.trust
 	test(function() {return m.trust("test").valueOf() === "test"})


### PR DESCRIPTION
Background:

In ES6 we now have `Object.setPrototypeOf` which makes prototype delegation an alternative to *sugary*, fake class coding patterns. This can be accomplished in ES5, but ES6 makes it much more elegant. Here is a basic example. `new` is never used and `this` is very easy to follow.

Working example with changes to mithril.js on lines 854, 858, 859 *only*.
http://jsbin.com/nopugo/1/edit?js,console,output

```javascript

'use strict'

const m = require('mithril')

const DataModel = {
    data: [1,2,3],
    getData(){
        console.log('getting data from server')
        return this.data
    },
    postData(val){
        console.log('sending data to server')
        this.data.push(val)
    }
}
const ViewModel = {
    filterEvenData: function() {
        return this.getData().filter((val) => (val % 2 === 0) && (+val !== 0))
    },
    addNewData: function(val){
        console.log('adding new data', val)
        this.postData(val)
    }
}

var Model = Object.setPrototypeOf(ViewModel, DataModel)

const App = {

    controller(){},

    view(ctrl){
        return m('div', [
            m('pre', [ 'EVEN NUMBERS IN DATA\n',
                this.filterEvenData().map((key,i) =>`${i+1} = ${key}\n`)                
            ]),
            m('div', 'Enter a number'),
            m('input[placeholder=number]', {
                // normally callback is called with `this` === `undefined`
                onchange: m.withAttr('value', App.addNewData, App),
                value: null
                }
            )
        ]) 
    }
}
Object.setPrototypeOf(App, Model)

m.mount(document.body, App)

```