### PR TITLE
Make m.route.param() return all params

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -958,6 +958,9 @@ var m = (function app(window, undefined) {
 	};
 	m.route.param = function(key) {
 		if (!routeParams) throw new Error("You must call m.route(element, defaultRoute, routes) before calling m.route.param()");
+		if( !key ){
+			return routeParams;
+		}
 		return routeParams[key];
 	};
 	m.route.mode = "search";

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -2579,6 +2579,27 @@ function testMithril(mock) {
 
 		return result
 	})
+	test(function() { // test route params returning params object if no key is given
+		mock.requestAnimationFrame.$resolve() //setup
+
+		var root = mock.document.createElement("div")
+		m.route.mode = "search"
+		m.route(root, "/", {
+			"/": {controller: function() {}, view: function() {}},
+			"/test12": {controller: function() {}, view: function() {}}
+		})
+		mock.requestAnimationFrame.$resolve()
+		m.route("/test12", {a: "foo", b: "bar"})
+		mock.requestAnimationFrame.$resolve()
+		
+		var params = m.route.param();
+
+		var result = params.a === "foo" && params.b === "bar"
+
+		m.mount(root, null) //teardown
+
+		return result
+	})
 	test(function() {
 		mock.requestAnimationFrame.$resolve() //setup
 		mock.location.search = "?"


### PR DESCRIPTION
This is a pull-request for the feature suggested here: #737

I've tried adding a test to confirm the feature works. Did it through simple TDD. But I'd like to know if there's some special way tests are to be done (seems a bit confusing). I just copied another test focusing on params and query search string and modified it.
