### PR TITLE
Typescript: Make MithrilVirtualElement and MithrilRoutes non-generic

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -20,13 +20,13 @@ declare module _mithril {
 		* @see m.mount
 		* @see m.component
 		*/
-		<T extends MithrilController>(
+		(
 			selector: string,
 			attributes: MithrilAttributes,
 			...children: Array<string |
-				MithrilVirtualElement<T> |
-				MithrilComponent<T>>
-		): MithrilVirtualElement<T>;
+				MithrilVirtualElement |
+				MithrilComponent<MithrilController>>
+		): MithrilVirtualElement;
 		
 		/**
 		* Creates a virtual element for use with m.render, m.mount, etc.
@@ -40,12 +40,12 @@ declare module _mithril {
 		* @see m.mount
 		* @see m.component
 		*/
-		<T extends MithrilController>(
+		(
 			selector: string,
 			...children: Array<string |
-				MithrilVirtualElement<T> |
-				MithrilComponent<T>>
-		): MithrilVirtualElement<T>;
+				MithrilVirtualElement |
+				MithrilComponent<MithrilController>>
+		): MithrilVirtualElement;
 
 		/**
 		* Initializes a component for use with m.render, m.mount, etc.
@@ -364,9 +364,9 @@ declare module _mithril {
 		* @param forceRecreation If true, overwrite the entire tree without
 		* diffing against it.
 		*/
-		render<T extends MithrilController>(
+		render(
 			rootElement: Element,
-			children: MithrilVirtualElement<T>|MithrilVirtualElement<T>[],
+			children: MithrilVirtualElement|MithrilVirtualElement[],
 			forceRecreation?: boolean
 		): void;
 
@@ -451,7 +451,7 @@ declare module _mithril {
 				element: Element,
 				isInitialized: boolean,
 				context?: MithrilContext,
-				vdom?: MithrilVirtualElement<T>
+				vdom?: MithrilVirtualElement
 			): void;
 
 			/**
@@ -615,7 +615,7 @@ declare module _mithril {
 	*
 	* @see m
 	*/
-	interface MithrilVirtualElement<T extends MithrilController> {
+	interface MithrilVirtualElement {
 		/**
 		* A key to optionally associate with this element.
 		*/
@@ -634,7 +634,7 @@ declare module _mithril {
 		/**
 		* The children of this element.
 		*/
-		children?: Array<string|MithrilVirtualElement<T>|MithrilComponent<T>>;
+		children?: Array<string|MithrilVirtualElement|MithrilComponent<MithrilController>>;
 	}
 
 	/**
@@ -686,11 +686,11 @@ declare module _mithril {
 		* @param context The associated context for this element.
 		* @param vdom The associated virtual element.
 		*/
-		<T extends MithrilController>(
+		(
 			element: Element,
 			isInitialized: boolean,
 			context: MithrilContext,
-			vdom: MithrilVirtualElement<T>
+			vdom: MithrilVirtualElement
 		): void;
 	}
 
@@ -758,7 +758,7 @@ declare module _mithril {
 		/**
 		* Creates a view out of virtual elements.
 		*/
-		(ctrl: T): MithrilVirtualElement<T>;
+		(ctrl: T): MithrilVirtualElement;
 	}
 
 	/**
@@ -781,7 +781,7 @@ declare module _mithril {
 		*
 		* @see m.component
 		*/
-		view(ctrl: T): MithrilVirtualElement<T>;
+		view(ctrl: T): MithrilVirtualElement;
 	}
 
 	/**
@@ -805,7 +805,7 @@ declare module _mithril {
 		*
 		* @see m.component
 		*/
-		view(ctrl: TController, arg1: T1, arg2: T2, arg3: T3, arg4: T4, ...args:any[]): MithrilVirtualElement<TController>;
+		view(ctrl: TController, arg1: T1, arg2: T2, arg3: T3, arg4: T4, ...args:any[]): MithrilVirtualElement;
 	}
 
 	/**

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -431,10 +431,10 @@ declare module _mithril {
 			* @param defaultRoute The route to start with.
 			* @param routes A key-value mapping of pathname to controller.
 			*/
-			<T extends MithrilController>(
+			(
 				rootElement: Element,
 				defaultRoute: string,
-				routes: MithrilRoutes<T>
+				routes: MithrilRoutes
 			): void;
 
 			/**
@@ -447,7 +447,7 @@ declare module _mithril {
 			* m("a[href='/dashboard/alicesmith']", {config: m.route});
 			* ```
 			*/
-			<T extends MithrilController>(
+			(
 				element: Element,
 				isInitialized: boolean,
 				context?: MithrilContext,
@@ -876,12 +876,12 @@ declare module _mithril {
 	/**
 	* This represents a key-value mapping linking routes to components.
 	*/
-	interface MithrilRoutes<T extends MithrilController> {
+	interface MithrilRoutes {
 		/**
 		* The key represents the route. The value represents the corresponding
 		* component.
 		*/
-		[key: string]: MithrilComponent<T>;
+		[key: string]: MithrilComponent<MithrilController>;
 	}
 
 	/**


### PR DESCRIPTION
Two proposed commits, which would make MithrilVirtualElement and MithrilRoutes non-generic.

These changes are suggested because of issues arising from TypeScript's limited ability to infer types.  [This simple example](http://bit.ly/1JDvezX) on the Typescript playground illustrates the particular problem.

To illustrate in terms of Mithril, here is an example of a typical call to `m.route()`:
```TypeScript
m.route(document.body, "/a", {
    "/a": ComponentA,
    "/b": ComponentB,
})
```

In this example, assume both `ComponentA` and `ComponentB` implement `MithrilComponent<T extends
MithrilController>`, with each component having a different concrete controller
type (`ControllerA` and `ControllerB` respectively).

Unless ControllerA's type is a subset of ControllerB's type (or
vice-versa), TypeScript will be unable to infer the type of the `MithrilRoutes<T>`
generated by `m.route()` - this is the same thing that happens in the simple playground example, where neither `Bar` nor `Baz` is a proper subset of the other. To get the call to m.route() to compile, a third type which *is* a subset of both ControllerA and ControllerB would need to be explicity provided:

```TypeScript
// Both ControllerA and ControllerB implement MithrilController
m.route<MithrilController>(document.body, "/a", {
  "/a": ComponentA,
  "/b": ComponentB,
})
```

A similar situation is needed for plain `m()`:
```TypeScript
function view(ctrl: ParentController): MithrilVirtualElement<MithrilController> {
   return m<MithrilController>("div", [
     m.component(ComponentA),
     m.component(ComponentB)
   ])
}
```
There are a number of factors which motivate a change:

1. In the case where either `m()` or `m.route()` does not compile due to type-inference failure,
the resulting syntax error from Typescript is very unhelpful because both m() and m.route()
have a large number of overloads. Leaving this as is will likely result in confusion for
downstream users.
2. Relatively little utility is provided by defining either `MithrilRoutes<T>` or `MithrilVirtualElement<T>` over a type more specific than MithrilController. At most, it could be used as a form of type assertion to ensure that there is a more specific common interface for the components of a specific application.
3. Even given the possibility of using these generic collections as a type assertion, more common use cases would see TypeScript/Mithril developers specifying `m.route<MithrilController>` or `m<MithrilController>` all over the place just to get the code to compile; this provides no additional type-safety over a non-generic interface and increases boilerplate in an unpredictable fashion.

Instead, these commits adjust both of these container types to be non-generic; instead, they always contain collections of `MithrilComponent<MithrilController>`, which will match all valid MithrilComponents.