### PR TITLE
Add Range.createContextualFragment to mock.js

### DIFF
--- a/tests/mock.js
+++ b/tests/mock.js
@@ -124,6 +124,16 @@ mock.window = (function() {
 		traverse(window.document);
 		return out;
 	}
+	try {
+		this.document.createRange().createContextualFragment('x')
+		window.document.createRange = function() {
+			return {
+				createContextualFragment: function (tagString) {
+					return window.document.createTextNode(tagString)
+				}
+			}
+		}
+	} catch (e) {}
 	window.scrollTo = function() {}
 	window.cancelAnimationFrame = function() {}
 	window.requestAnimationFrame = function(callback) {


### PR DESCRIPTION
The test doesn't work properly on Web Browser.
So, I add `document.createRange` and `Range.createContextualFragment` to tests/mock.js.