### PR TITLE
fixes type for MithrilControllerFunction

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -92,8 +92,8 @@ declare module _mithril {
 		onunload?(evt: Event): any;
 	}
 
-	interface MithrilControllerFunction extends MithrilController {
-		(): any;
+	interface MithrilControllerFunction<T extends MithrilController> {
+		(attributes?: any, ... args : any[]): T;
 	}
 
 	interface MithrilView<T extends MithrilController> {
@@ -101,7 +101,7 @@ declare module _mithril {
 	}
 
 	interface MithrilComponent<T extends MithrilController> {
-		controller: MithrilControllerFunction|{ new(): T };
+		controller: MithrilControllerFunction<T>|{ new(): T };
 		view: MithrilView<T>;
 	}
 

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -153,6 +153,7 @@ declare module _mithril {
 		password?: string;
 		data?: any;
 		background?: boolean;
+		initialValue?: any;
 		unwrapSuccess?(data: any): any;
 		unwrapError?(data: any): any;
 		serialize?(dataToSerialize: any): string;


### PR DESCRIPTION
MithrilControllerFunction, as used in MithrilComponent, is not a 
controller itself, but a function returning a controller. The current 
documentation also allows the controller function to be 
called with an attributes object and additional arguments. This was not
reflected in the corresponding TypeScript type.