### PR TITLE
Fix MIT license annotation in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,7 @@
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "files": [
     "mithril.min.js",
     "mithril.min.js.map",


### PR DESCRIPTION
As per https://docs.npmjs.com/files/package.json#license, the package.json was using the old format, which throws a command line error when running `npm install`.

Shaves a few bytes off the repo too! ;)