### PR TITLE
Read version number + other info from package.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,8 @@
 /* eslint-env node */
 module.exports = function (grunt) { // eslint-disable-line
-	var version = "0.2.1"
 
+	var pkg = grunt.file.readJSON("package.json")
+	var currentYear = grunt.template.today("yyyy")
 	var inputFolder = "./docs"
 	var tempFolder = "./temp"
 	var archiveFolder = "./archive"
@@ -72,7 +73,7 @@ module.exports = function (grunt) { // eslint-disable-line
 	makeTasks("guide", guide)
 	makeTasks("api", api)
 
-	var currentVersionArchiveFolder = archiveFolder + "/v" + version
+	var currentVersionArchiveFolder = archiveFolder + "/v" + pkg.version
 
 	grunt.initConfig({
 		// Keep this in sync with the .eslintignore
@@ -107,10 +108,10 @@ module.exports = function (grunt) { // eslint-disable-line
 			options: {
 				banner: [
 					"/*",
-					"Mithril v" + version,
-					"http://github.com/lhorie/mithril.js",
-					"(c) Leo Horie",
-					"License: MIT",
+					pkg.name + " v" + pkg.version,
+					pkg.homepage,
+					"(c) 2014-" + currentYear + " " + pkg.author.name,
+					"License: " + pkg.license,
 					"*/"
 				].join("\n"),
 				sourceMap: true
@@ -135,7 +136,7 @@ module.exports = function (grunt) { // eslint-disable-line
 				force: true,
 				patterns: [
 					{match: /\.md/g, replacement: ".html"},
-					{match: /\$version/g, replacement: version}
+					{match: /\$version/g, replacement: pkg.version}
 				]
 			},
 
@@ -232,7 +233,7 @@ module.exports = function (grunt) { // eslint-disable-line
 				expand: true,
 				cwd: currentVersionArchiveFolder,
 				src: "./**",
-				dest: outputFolder + "/archive/v" + version
+				dest: outputFolder + "/archive/v" + pkg.version
 			}
 		},
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
-  "name": "mithril",
+  "name": "Mithril",
   "description": "Mithril.js beta build - use this to help us test the releases before they are released",
   "version": "0.2.1",
+  "homepage": "http://mithril.js.org",
+  "license": "MIT",
+  "author": {
+    "name": "Leo Horie"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:lhorie/mithril.js.git"
+  },
+  "bugs": {
+    "url" : "http://github.com/lhorie/mithril.js/issues"
   },
   "scripts": {
     "test": "grunt test"
@@ -33,7 +41,6 @@
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },
-  "license": "MIT",
   "files": [
     "mithril.min.js",
     "mithril.min.js.map",


### PR DESCRIPTION
My original intention was simply to avoid duplicating the version number more than necessary (it remains duplicated as a constant in mithril.js), but then figured we might as well treat the package.json as the config object that it is.

Note that the banner in the generated mithril.min.js changes to this:

    /*
    Mithril v0.2.1
    http://mithril.js.org
    (c) 2014-2015 Leo Horie
    License: MIT
    */

...from this:

    /*
    Mithril v0.2.1
    http://github.com/lhorie/mithril.js
    (c) Leo Horie
    License: MIT
    */

If you prefer to point towards the GitHub repo, then that line needs to be changed back to its former static value (`pkg.repository.url` is required to be the machine-readable clone url, so that can't really be used).