### PR TITLE
Point Download button and topnav link to installation.html

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ Mithril is available from a variety of sources:
 
 ### Direct download
 
-You can [download a zip of the latest version version here](http://lhorie.github.io/mithril/mithril.min.zip).
+You can [download a zip of the latest version version here](mithril.min.zip).
 
 Links to older versions can be found in the [change log](change-log.html).
 

--- a/docs/layout/api.html
+++ b/docs/layout/api.html
@@ -14,7 +14,7 @@
 				<a href="mithril.html">API</a>
 				<a href="community.html">Community</a>
 				<a href="http://lhorie.github.io/mithril-blog">Learn</a>
-				<a href="mithril.min.zip">Download</a>
+				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
 		</header>

--- a/docs/layout/guide.html
+++ b/docs/layout/guide.html
@@ -14,7 +14,7 @@
 				<a href="mithril.html">API</a>
 				<a href="community.html">Community</a>
 				<a href="http://lhorie.github.io/mithril-blog">Learn</a>
-				<a href="mithril.min.zip">Download</a>
+				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
 		</header>

--- a/docs/layout/index.html
+++ b/docs/layout/index.html
@@ -14,7 +14,7 @@
 				<a href="mithril.html">API</a>
 				<a href="community.html">Community</a>
 				<a href="http://lhorie.github.io/mithril-blog">Learn</a>
-				<a href="mithril.min.zip">Download</a>
+				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
 		</header>
@@ -28,7 +28,7 @@
 
 					<p>
 						<a class="button" href="getting-started.html">Guide</a>
-						<a class="button" href="mithril.min.zip">Download v$version</a>
+						<a class="button" href="installation.html">Download v$version</a>
 					</p>
 					
 					<iframe src="ghbtns.html?user=lhorie&amp;repo=mithril.js&amp;type=watch&amp;count=true" frameborder="0" scrolling="0" width="100" height="20"></iframe>


### PR DESCRIPTION
Being pointed directly to a .zip-download from a link in the main navigation is a little jarring and unexpected for most users, I would wager.

And the user might as well be looking for one of the alternative options detailed on the [installation page](http://mithril.js.org/installation.html) — or if not, then the first link on that page is still to the .zip-file.