### PR TITLE
Pass event as second parameter to m.withAttr callback

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1425,7 +1425,7 @@ void (function (global, factory) { // eslint-disable-line
 				targetProp = currentTarget.getAttribute(prop)
 			}
 
-			withAttrCallback.call(_this, targetProp)
+			withAttrCallback.call(_this, targetProp, e)
 			/* eslint-enable no-invalid-this */
 		}
 	}


### PR DESCRIPTION
Pass the original `event` to the callback function of `m.withAttr()`

e.g.:

    m("input", {
      onkeyup: m.withAttr("value", function(val, event){
        if(event.keyCode == 13){
         // do something...
        }else{
         // do something else...
        }
      });
    })