### PR TITLE
fix subcomponent unloading

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -729,15 +729,19 @@ void (function (global, factory) { // eslint-disable-line
 	var unloaders = []
 
 	function updateLists(views, controllers, view, controller) {
-		if (controller.onunload != null) {
-			unloaders.push({
-				controller: controller,
-				handler: controller.onunload
-			})
-		}
-
 		views.push(view)
-		controllers.push(controller)
+		var idx = controllers.push(controller) - 1
+		unloaders[idx] = {
+			controller: controller,
+			handler: function () {
+				controllers.splice(controllers.indexOf(controller), 1)
+				views.splice(views.indexOf(view), 1)
+				var unload = controller && controller.onunload
+				if (type.call(unload) === "[object Function]") {
+					controller.onunload()
+				}
+			}
+		}
 	}
 
 	var forcing = false
@@ -1300,6 +1304,7 @@ void (function (global, factory) { // eslint-disable-line
 		}
 
 		forEach(unloaders, function (unloader) {
+			if (unloader.controller == null) return
 			unloader.handler.call(unloader.controller, ev)
 			unloader.controller.onunload = null
 		})


### PR DESCRIPTION
fixes #866, and should fix #614 as well

adds a handler to the unloaders array every time a controller is created.

Said handler removes the view from the views array and controller from the controllers array making sure that unload actually means "I should not exist anymore"