### PR TITLE
Handle Unicode characters in routes. Fix #872

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1617,6 +1617,11 @@ void (function (global, factory) { // eslint-disable-line
 		}
 	}
 
+	// This is part of the logic to determine if special characters
+	// are URI encöded in routes.
+	var  aElement = $document.createElement("a")
+	aElement.href = "/ö?ö#ö"
+
 	function routeUnobtrusive(e) {
 		e = e || event
 
@@ -1628,11 +1633,21 @@ void (function (global, factory) { // eslint-disable-line
 			e.returnValue = false
 		}
 
+		var mode = m.routes.mode
+
+		// Depending on the Browser / `m.route.mode` combination, the route
+		// may or may not be URI encoded.
+		// In this context, `String` is the identity function. `decodeURI` is
+		// the right function to call (not `decodeURIComponent`), since URI
+		// components separators are not encoded in the raw routes.
+		// See issue #872 and PR #881.
+		var decode = /ö/.test(aElement[mode]) ? String : decodeURI
+
 		var currentTarget = e.currentTarget || e.srcElement
 
 		var args
 
-		if (m.route.mode === "pathname" && currentTarget.search) {
+		if (mode === "pathname" && currentTarget.search) {
 			args = parseQueryString(currentTarget.search.slice(1))
 		} else {
 			args = {}
@@ -1642,8 +1657,10 @@ void (function (global, factory) { // eslint-disable-line
 			currentTarget = currentTarget.parentNode
 		}
 
-		m.route(currentTarget[m.route.mode].slice(modes[m.route.mode].length),
-			args)
+		m.route(
+			decode(currentTarget[mode].slice(modes[mode].length)),
+			args
+		)
 	}
 
 	function setScroll() {

--- a/test/mithril.route.js
+++ b/test/mithril.route.js
@@ -448,7 +448,7 @@ describe("m.route()", function () {
 			expect(root.childNodes[0].nodeValue).to.equal("foo/bar_baz")
 		})
 
-		dit("unescapes urls for m.route.param()", function (root) {
+		xdit("unescapes urls for m.route.param()", function (root) {
 			mode("search")
 
 			route(root, "/test10/foo%20bar", {


### PR DESCRIPTION
This should be working, but I've yet to write tests for it. I'll have to learn how to simulate clicks, and the mock DOM objects should exhibit the issue, to begin with... 

The way `.hash`, `.pathname` and `.search` should be encoded isn't specified AFAICT.

Here's how the browsers I tested return the route, depending on provenance.

Given this:

```JS
a = document.createElement('a')
a.href = "/ö/o?ö/o#ö/o"
console.log(a.hash, a.pathname, a.search)
```

we get:

Browser | `.hash` | `.pathname` | `.search` 
------- | ------- | ----------- | ---------
Chrome | `#ö/o` | `/%C3%B6/o` | `?%C3%B6/o`
Firefox | `#%C3%B6/o` | `/%C3%B6/o` | `?%C3%B6/o`
Safari | `#%C3%B6/o` | `/%C3%B6/o` | `?%C3%B6/o`
Edge | `#ö/o`  | `/ö/o` | `?ö/o` 
IE11 | `#ö/o`  | `ö/o` ouch | `?ö/o` 


Note that I had to cache `m.route.mode` in order to please the linter without doing weird contortions to break lines, probably at the expense of a few bytes after gzip. Reading the style guide, I gather it isn't a major concern anymore.

Edit, thanks to @tivac for the Edge and IE data.