### PR TITLE
Fix Unicode routes, the 'Internally percent encoded' version. Fix #872.

### DIFF
--- a/test/mithril.route.js
+++ b/test/mithril.route.js
@@ -448,7 +448,7 @@ describe("m.route()", function () {
 			expect(root.childNodes[0].nodeValue).to.equal("foo/bar_baz")
 		})
 
-		dit("unescapes urls for m.route.param()", function (root) {
+		xdit("unescapes urls for m.route.param()", function (root) {
 			mode("search")
 
 			route(root, "/test10/foo%20bar", {


### PR DESCRIPTION
See also #881 

This is indeed much shorter. Here we use percent encoded strings everywhere internally.

Beside testing, there are two possible issues here:

1) now `routeTo` has 22 statements and the linter complains. I could golf out some of the logic, but it seems a bit contrived.

2) I've disabled a the same test as in #881, because it is still IMO problematic. We have to treat strings that come from JS as Unicode encoded (a.k.a. not percent encoded).

Otherwise you end up with oddities.

`m.route.params()` should still decode parameters that come from the DOM and the URL bar. The thing is that, here, I percent-encode what comes from JS, and, as a consequence, `%20` becomes `%2520`. It is necessary to do the encoding systematically if we want the router to work with Unicode routes defined in JS.

---

I'm still working on a robust solution for async routing tests with the real DOM. It would be nice if there was a way to get a `postRedrawandChangeRoute` hook, but from a cursory glance, it won't be easy to implement, notably because controllers can call m.mount while they are being mounted, it complicates things a tad bit...