### PR TITLE
a fix for an edge case w/ contenteditable & m.trust

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -507,6 +507,7 @@
 			} else if (editable) {
 				// contenteditable nodes use `innerHTML` instead of `nodeValue`.
 				editable.innerHTML = data
+				nodes = [].slice.call(editable.childNodes)
 			} else {
 				// was a trusted string
 				if (nodes[0].nodeType === 1 || nodes.length > 1 ||

--- a/test/mithril.render.js
+++ b/test/mithril.render.js
@@ -1549,5 +1549,17 @@ describe("m.render()", function () {
 			expect(root.childNodes[0].innerHTML)
 				.to.equal('<option value="">aaa</option>')
 		})
+
+		it("caches children of editable on update", function () {
+			var root = document.createElement("span")
+			var t1 = m.trust("<h1>fo</h1>o")
+			var t2 = "foo"
+
+			m.render(root, m("span", {contenteditable: false}, t1))
+			m.render(root, m("span", {contenteditable: true}, t2))
+			m.render(root, m("span", {contenteditable: false}, t1))
+
+			expect(root.childNodes[0].innerHTML).to.equal(t1.valueOf())
+		})
 	})
 })

--- a/test/mithril.trust.js
+++ b/test/mithril.trust.js
@@ -64,5 +64,18 @@ describe("m.trust()", function () {
 			expect(root.innerHTML).to.equal("<div><p>&amp;copy;</p><p>©</p>©</div>")
 		})
 
+		// not sure that this goes here; not really an m.trust issue
+		it("caches children of editable on update", function () {
+			var root = document.createElement("table")
+			var t1 = m.trust("<h1>fo</h1>o")
+			var t2 = "foo"
+
+			m.render(root, m("span", {contenteditable: false}, t1))
+			m.render(root, m("span", {contenteditable: true}, t2))
+			m.render(root, m("span", {contenteditable: false}, t1))
+
+			expect(root.childNodes[0].innerHTML).to.equal(t1.valueOf())
+		})
+
 	})
 })

--- a/test/mithril.trust.js
+++ b/test/mithril.trust.js
@@ -64,18 +64,5 @@ describe("m.trust()", function () {
 			expect(root.innerHTML).to.equal("<div><p>&amp;copy;</p><p>©</p>©</div>")
 		})
 
-		// not sure that this goes here; not really an m.trust issue
-		it("caches children of editable on update", function () {
-			var root = document.createElement("table")
-			var t1 = m.trust("<h1>fo</h1>o")
-			var t2 = "foo"
-
-			m.render(root, m("span", {contenteditable: false}, t1))
-			m.render(root, m("span", {contenteditable: true}, t2))
-			m.render(root, m("span", {contenteditable: false}, t1))
-
-			expect(root.childNodes[0].innerHTML).to.equal(t1.valueOf())
-		})
-
 	})
 })


### PR DESCRIPTION
when setting new content for an editable node that previously had m.trust'ed content, it's children are not cached; so if you make it non editable and set m.trust'ed content again, it doubles it up because it clears nodes that are no longer there and prepends the new m.trust'ed content.

here is a fiddle to better demonstrate the issue (click on the button 3+ times): 
https://jsfiddle.net/39a3ej6g/7/
