### PR TITLE
`m.hook()`, `m.hooks`...

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -2283,13 +2283,22 @@
 		return deferred.promise
 	}
 
+	function deferred() {
+		var prm = {}
+		prm.promise = new Promise(function(R,r){
+			prm.resolve = R
+			prm.reject = r
+		})
+		return prm
+	}
+
 	m.hook = mhook
 	function mhook(prop) {
-		var prm = m.deferred()
+		var prm = deferred()
 		prop(prm.promise)
 		return function(value) {
 			prm.resolve(value)
-			prm = m.deferred()
+			prm = deferred()
 			prop(prm.promise)
 		}
 	}
@@ -2299,9 +2308,9 @@
 		routeChange: gettersetter(),
 		locationChange: gettersetter()
 	}
-	var triggerRedrawHook = mhook(m.hooks.nextRedraw)
-	var triggerRouteChangeHook = mhook(m.hooks.nextRouteChange)
-	var triggerLocationChangeHook = mhook(m.hooks.nextLocationChange)
+	var triggerRedrawHook = mhook(m.hooks.redraw)
+	var triggerRouteChangeHook = mhook(m.hooks.routeChange)
+	var triggerLocationChangeHook = mhook(m.hooks.locationChange)
 
 	return m
 })


### PR DESCRIPTION
This is not ready for inclusion, but I wanted to spark the debate.

Here's the core:

```JS
	m.hook = mhook
	function mhook(prop) {
		var prm = deferred()
		prop(prm.promise)
		return function(value) {
			prm.resolve(value)
			prm = deferred()
			prop(prm.promise)
		}
	}

	m.hooks = {
		redraw: gettersetter()
	}
	var triggerRedrawHook = mhook(m.hooks.redraw) // call that in the right location.
```

This adds promise-backed, one shot event listeners. m.hook.redraw() always returns a promise that is not resolved, and will be resolved by the trigger.

I allows me to do things like this:

```JavaScript

    dit("clicks a link bound to an ascii route (hash mode)", function (done) {
        setTimeout(function () { // we must be async
            mode("hash")

            var routeChange = m.hooks.routeChange()
            var locationChange = m.hooks.locationChange()
            var redraw = m.hooks.redraw()

            m.route(theatre, "/entry", {
                "/entry": pure(function () {
                    return m("a[href=/foo]", {config: m.route}, "CLICK ME")
                }),
                "/foo": pure(function () {
                    return "foo"
                })

            })
            m.route("/entry")
            m.redraw(true)
            m.route("/entry")
            m.redraw(true)

            routeChange.then(function (route){
                expect(route).to.equal("/entry")
                expect(window.location.hash).to.equal("#/entry")

                return redraw // this may already be resolved by now.
            }).then(function (node) { // the root node, comes from the redraw hook
                // reset the hooks
                routeChange = m.hooks.routeChange()
                redraw = m.hooks.redraw()
                locationChange = m.hooks.locationChange()
                var link = node.childNodes[0]
                expect(link.hash).to.equal("#/foo")
                click(link) //hehe

                return redraw
            }).then(function(node){
                expect(node.innerHTML).to.equal("foo")

            }).then(done.bind(null,null), done)
        }, 0)
    })

```

Where `dit` is adapted to call `dom()` rather than passing a root element.

Another case where the current implementation of Mithril promises fails, I had to wrap native promises. The `deferred` API is better for that use case, though.

I my not have placed the triggers in the right spots (especially the `redraw` hook).