### PR TITLE
Add preversion hook (fixes #827)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "http://github.com/lhorie/mithril.js/issues"
   },
   "scripts": {
+    "preversion": "grunt",
     "test": "grunt test"
   },
   "main": "mithril.js",


### PR DESCRIPTION
@lhorie 

Presumably, you're already using `npm version` to generate the tags before publishing, and this hooks into that, running `grunt build` before the version tag is generated. If you'd prefer some other hook, it's easy to change (and it's simple enough you could probably clone and push directly about as quickly).