### PR TITLE
Start m.prop fix/support for ES6 Promises [WIP]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,10 @@
 		"browser": true
 	},
 
+    "global": {
+        "Promise": false
+    },
+
 	"rules": {
 		"indent": [2, "tab"],
 		"no-trailing-spaces": 2,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "chai": "^3.4.0",
     "chai-string": "^1.1.4",
+    "es6-promise": "^3.0.2",
     "eslint": "^1.7.3",
     "grunt": "*",
     "grunt-cli": "*",

--- a/test/index.html
+++ b/test/index.html
@@ -4,6 +4,7 @@
 <div id="mocha"></div>
 
 <!-- Dependencies -->
+<script src="../node_modules/es6-promise/dist/es6-promise.js"></script>
 <script src="../node_modules/chai/chai.js"></script>
 <script src="../node_modules/chai-string/chai-string.js"></script>
 <script src="../node_modules/sinon/pkg/sinon.js"></script>

--- a/test/mithril.prop.js
+++ b/test/mithril.prop.js
@@ -101,7 +101,7 @@ describe("m.prop()", function () {
 	})
 
 	it("returns a callable when `finally` is called", function () {
-		var promise = Promise.reject(2)
+		var promise = Promise.resolve(2)
 		var spy = sinon.spy()
 		var prop = m.prop(promise).finally(spy)
 

--- a/test/mithril.prop.js
+++ b/test/mithril.prop.js
@@ -50,7 +50,7 @@ describe("m.prop()", function () {
 		expect(prop()).to.equal("test")
 	})
 
-	it("returns a thenable when wrapping a Mithril promise", function () {
+	it("returns a callable thenable when wrapping a Mithril promise", function () { // eslint-disable-line max-len
 		var defer = m.deferred()
 
 		var prop = m.prop(defer.promise).then(function () {
@@ -61,4 +61,44 @@ describe("m.prop()", function () {
 
 		expect(prop()).to.equal("test2")
 	})
+
+	it("provides a way to wrap promises", function () {
+		var promise = Promise.resolve()
+		var prop = m.prop(promise)
+		// `then` is called, so identity doesn't hold.
+		expect(prop.promise()).to.be.an.instanceof(Promise)
+	})
+
+	it("returns a callable when wrapping a thenable", function () {
+		var prop = m.prop(Promise.resolve(2))
+		return prop.promise().then(function (value) {
+			expect(value).to.equal(2)
+		})
+	})
+
+	it("returns a callable when `then` is called", function () {
+		var promise = Promise.resolve(2)
+		var spy = sinon.spy()
+		var prop = m.prop(promise).then(spy)
+
+		return prop.promise().then(function (value) {
+			expect(spy).to.be.calledWith(2)
+			expect(prop()).to.equal(2)
+			expect(value).to.equal(2)
+		})
+	})
+
+	it("returns a callable when `catch` is called", function () {
+		var promise = Promise.reject(2)
+		var spy = sinon.spy()
+		var prop = m.prop(promise).catch(spy)
+
+		return prop.promise().then(function (value) {
+			expect(spy).to.be.calledWith(2)
+			expect(prop()).to.equal(2)
+			expect(value).to.equal(2)
+		})
+	})
+
+	this.timeout(0)
 })

--- a/test/mithril.prop.js
+++ b/test/mithril.prop.js
@@ -100,5 +100,18 @@ describe("m.prop()", function () {
 		})
 	})
 
-	this.timeout(0)
+	it("returns a callable when `finally` is called", function () {
+		var promise = Promise.reject(2)
+		var spy = sinon.spy()
+		var prop = m.prop(promise).finally(spy)
+
+		return prop.promise().then(function (value) {
+			expect(spy).to.be.calledWith(2)
+			expect(prop()).to.equal(2)
+			expect(value).to.equal(2)
+		})
+	})
+
+	// TODO: take this out before merging
+	this.timeout(0) // eslint-disable-line no-invalid-this
 })


### PR DESCRIPTION
This got complicated quick.

Fixes #904 by partially reverting the changes to `m.prop()` in #893. It also adds more general support for any Promise implementation that implements the ES6 Promise interface (including the constructor). This could, in theory, include Bluebird promises as well.

Basically, unforeseen problems occurred with that API break, where it managed to cause several m.deferred regressions that weren't tested.

This is a massive work in progress, with two new and failing tests (with more to come). My biggest issue at the moment is a possible race condition preventing already-resolved values from being passed down the chain.