### PR TITLE
Support setting the Promise implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "url": "git@github.com:lhorie/mithril.js.git"
   },
   "bugs": {
-    "url" : "http://github.com/lhorie/mithril.js/issues"
+    "url": "http://github.com/lhorie/mithril.js/issues"
   },
   "scripts": {
     "test": "grunt test"
   },
   "main": "mithril.js",
   "devDependencies": {
+    "bluebird": "^3.1.1",
     "chai": "^3.4.0",
     "eslint": "^1.7.3",
     "grunt": "*",

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,7 @@
 
 <script src="../test-deps/dom.js"></script>
 <script src="../test-deps/mock.js"></script>
+<script src="../node_modules/bluebird/js/browser/bluebird.js"></script>
 <script src="../mithril.js"></script>
 <script>
 mocha.setup("bdd")

--- a/test/mithril.deferred.js
+++ b/test/mithril.deferred.js
@@ -307,4 +307,58 @@ describe("m.deferred()", function () {
 			expect(v).to.equal(5)
 		})
 	})
+
+	it("allows setting Bluebird as the Promise implementation", function (done) {
+		m.setPromiseImpl(Promise);
+		var d = m.deferred();
+		d.resolve('allows setting Bluebird as the Promise implementation');
+		m.setPromiseImpl(); // set back to the default impl
+
+		d.promise.then(function () {
+			expect(d.promise.isRejected()).to.equal(false);
+			done();
+		})
+	})
+
+	it("finally works with Bluebird", function (done) {
+		m.setPromiseImpl(Promise);
+		var d = m.deferred();
+		d.resolve('finally works with Bluebird');
+
+		d.promise.finally(function () {
+			// needs to happen in the finally block (next tick) since all Bluebird promise are resolved/rejected asynchronously
+			expect(d.promise.isPending()).to.equal(false);
+			expect(d.promise.isRejected()).to.equal(false);
+			done();
+		})
+		m.setPromiseImpl(); // set back to the default impl
+	})
+
+	it("catch string works with Bluebird", function (done) {
+		m.setPromiseImpl(Promise);
+		var d = m.deferred();
+
+		d.reject('catch String with Bluebird');
+
+		d.promise.catch(function () {
+			expect(d.promise.isPending()).to.equal(false);
+			expect(d.promise.isRejected()).to.equal(true);
+			done();
+		})
+		m.setPromiseImpl(); // set back to the default impl
+	})
+
+	it("catch Error works with Bluebird", function (done) {
+		m.setPromiseImpl(Promise);
+		var d = m.deferred();
+
+		d.reject(new Error('catch Error with Bluebird'));
+
+		d.promise.catch(function () {
+			expect(d.promise.isPending()).to.equal(false);
+			expect(d.promise.isRejected()).to.equal(true);
+			done();
+		})
+		m.setPromiseImpl(); // set back to the default impl
+	})
 })


### PR DESCRIPTION
This adds a m.setPromiseImpl = function(Promise) that sets the Promise function used by the Deferred function. If passed null or no arguments, e.g. m.setPromiseImpl(), reverts to the mithril built-in promise implementation.