### PR TITLE
Fix onunload test case

### DIFF
--- a/test/mithril.mount.js
+++ b/test/mithril.mount.js
@@ -333,12 +333,11 @@ describe("m.mount()", function () {
 			})
 		}))
 
-		list.pop()
+		list = []
 		refresh(true)
 
-		// TODO: These fail.
-		// expect(spies[1]).to.have.been.called
-		// expect(spies[2]).to.have.been.called
+		expect(spies[1]).to.have.been.called
+		expect(spies[2]).to.have.been.called
 		expect(spies[3]).to.have.been.called
 	})
 
@@ -374,17 +373,15 @@ describe("m.mount()", function () {
 			})
 		}))
 
-		list.pop()
+		list = []
 		refresh(true)
 
-		// TODO: These fail.
-		// expect(spies1[1]).to.have.been.called
-		// expect(spies1[2]).to.have.been.called
+		expect(spies1[1]).to.have.been.called
+		expect(spies1[2]).to.have.been.called
 		expect(spies1[3]).to.have.been.called
 
-		// TODO: These fail.
-		// expect(spies2[1]).to.have.been.called
-		// expect(spies2[2]).to.have.been.called
+		expect(spies2[1]).to.have.been.called
+		expect(spies2[2]).to.have.been.called
 		expect(spies2[3]).to.have.been.called
 	})
 


### PR DESCRIPTION
fix https://github.com/lhorie/mithril.js/issues/826

- the previous test only remove last item on array, but expect all
subcomponent's onunload to be called. This PR change it by clear that
array.
- uncomment previous test case that marked fail.