### PR TITLE
Small documentation tweak: kb -> kB

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Mithril is a client-side MVC framework - a tool to organize code in a way that i
 
 ### Light-weight
 
-- Only 7kb gzipped, no dependencies
+- Only 7.8 kB gzipped, no dependencies
 - Small API, small learning curve
 
 ### Robust

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -6,7 +6,7 @@ This page aims to provide a comparison between Mithril and some of the most wide
 
 ### Code Size
 
-One of the most obvious differences between Mithril and most frameworks is in file size: Mithril is around 7kb gzipped and has no dependencies on other libraries.
+One of the most obvious differences between Mithril and most frameworks is in file size: Mithril is around 7.8 kB gzipped and has no dependencies on other libraries.
 
 Note that while a small gzipped size can look appealing, that number is often used to "hide the weight" of the uncompressed code: remember that the decompressed Javascript still needs to be parsed and evaluated on every page load, and this cost (which can be in the dozens of milliseconds range for some frameworks in some browsers) cannot be cached.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@
 
 Mithril is a client-side Javascript MVC framework, i.e. it's a tool to make application code divided into a data layer (called **M**odel), a UI layer (called **V**iew), and a glue layer (called **C**ontroller)
 
-Mithril is around 7kb gzipped thanks to its [small, focused, API](mithril.md). It provides a templating engine with a virtual DOM diff implementation for performant rendering, utilities for high-level modelling via functional composition, as well as support for routing and componentization.
+Mithril is around 7.8 kB gzipped thanks to its [small, focused, API](mithril.md). It provides a templating engine with a virtual DOM diff implementation for performant rendering, utilities for high-level modelling via functional composition, as well as support for routing and componentization.
 
 The goal of the framework is to make application code discoverable, readable and maintainable, and hopefully help you become an even better developer.
 

--- a/docs/layout/index.html
+++ b/docs/layout/index.html
@@ -50,7 +50,7 @@
 					<div class="feature col(4,4,12)">
 						<h2>Light-weight</h2>
 						<ul>
-							<li>Only 7kb gzipped, no dependencies</li>
+							<li>Only 7.8 kB gzipped, no dependencies</li>
 							<li>Small API, small learning curve</li>
 						</ul>
 					</div>


### PR DESCRIPTION
A very little nit-picky documentation change, but why not make mithril a tiny bit more beautiful!

I noticed the reference to a gzipped size of "7kb" throughout the docs.  "kb" refers to [kilobit, not kilobyte](https://en.wikipedia.org/wiki/Byte#Unit_symbol) and there should be [a space in between the number and unit symbol](https://en.wikipedia.org/wiki/International_System_of_Units#Unit_names_as_adjectives).