### PR TITLE
Degenerify `MithrilRoutes`

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -250,7 +250,7 @@ declare module _mithril {
 			<T extends MithrilController>(
 				rootElement: Element,
 				defaultRoute: string,
-				routes: MithrilRoutes<T>
+				routes: MithrilRoutes
 			): void;
 
 			/**
@@ -668,12 +668,12 @@ declare module _mithril {
 	/**
 	* This represents a key-value mapping linking routes to components.
 	*/
-	interface MithrilRoutes<T extends MithrilController> {
+	interface MithrilRoutes {
 		/**
 		* The key represents the route. The value represents the corresponding
 		* component.
 		*/
-		[key: string]: MithrilComponent<T>;
+		[key: string]: MithrilComponent<MithrilController>;
 	}
 
 	/**


### PR DESCRIPTION
The routes type doesn't need to be parametrized. It's far too restricting and technically incorrect.