### PR TITLE
update typescript defs to support more accurate MithrilAttributes interface

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -534,6 +534,12 @@ declare module _mithril {
 		* @see MithrilElementConfig
 		*/
 		config?: MithrilElementConfig;
+
+		/**
+		* Any other virtual element properties including attributes and
+		* event handlers
+		*/
+		[property: string]: any;
 	}
 
 	/**


### PR DESCRIPTION
I think this is a more accurate definition. I'm seeing errors when I use code like this:

```m("a", {href: "...}, "link")```

The error is:
```Argument of type 'string' is not assignable to parameter of type 'ParameterizedMithrilComponent<{}, { style: string; }, MithrilComponent<Controller>, void, void>'.
  Property 'controller' is missing in type 'String'.```