### PR TITLE
Reapply docs fix

### DIFF
--- a/docs/mithril.component.md
+++ b/docs/mithril.component.md
@@ -43,7 +43,7 @@ var MyComponent = {
 m.mount(document.body, MyComponent) // renders <h1>Hello</h1> into <body>
 ```
 
-The optional `controller` function creates an object that may be used in the following recommended ways: 
+The optional `controller` function creates an object that may be used in the following recommended ways:
 
 - It can contain methods meant to be called by a `view`.
 - It can call model methods directly or from methods inside the resulting object.
@@ -211,7 +211,7 @@ var App = {
 	view: function() {
 		return m(".app", [
 			m("h1", "My App"),
-			
+
 			//nested component
 			m.component(MyComponent, {message: "Hello"})
 		])
@@ -246,7 +246,7 @@ var App = {
 		return m(".app", [
 			//pressing the button reverses the list
 			m("button[type=button]", {onclick: function() {ctrl.data.reverse()}}, "My App"),
-			
+
 			ctrl.data.map(function(item) {
 				//the key ensures the components aren't recreated from scratch, if they merely exchanged places
 				return m.component(MyComponent, {message: "Hello " + item, key: item})
@@ -327,12 +327,12 @@ var ctrl = new TemperatureConverter.controller();
 assert(ctrl.kelvinToCelsius(273.15) == 0)
 
 //test the template
-var tpl = TemperatureConverter.view(null, {value: 273.15})
+var tpl = TemperatureConverter.view(ctrl, {value: 273.15})
 assert(tpl.children[1] == 0)
 
 //test with real DOM
 var testRoot = document.createElement("div")
-m.render(testRoot, TemperatureConverter.view(null, {value: 273.15}))
+m.render(testRoot, TemperatureConverter.view(ctrl, {value: 273.15}))
 assert(testRoot.innerHTML.indexOf("celsius:0") > -1)
 ```
 
@@ -451,7 +451,7 @@ var component = {
 		var unsaved = m.prop(false)
 		return {
 			unsaved: unsaved,
-			
+
 			onunload: function(e) {
 				if (unsaved()) {
 					e.preventDefault()
@@ -538,7 +538,7 @@ There are a few other technical caveats when nesting components:
 2.	Nested components cannot change `m.redraw.strategy` from the controller constructor (but they can from event handlers). It's recommended that you use the [`ctx.retain`](mithril.md#persisting-dom-elements-across-route-changes) flag instead of changing the redraw strategy in controller constructors.
 
 3.	The root DOM element in a component's view must not be changed during the lifecycle of the component, otherwise undefined behavior will occur. In other words, don't do this:
-	
+
 	```javascript
 	var MyComponent = {
 		view: function() {
@@ -603,4 +603,3 @@ where:
 -	**returns Component parameterizedComponent**
 
 	A component with arguments bound
-


### PR DESCRIPTION
This is a reapplication of #940 against `next` (I instinctively did `master` by accident).