### PR TITLE
"Currently active component" is unhelpful at best, misleading at worst

### DIFF
--- a/docs/mithril.redraw.md
+++ b/docs/mithril.redraw.md
@@ -10,7 +10,7 @@
 
 ---
 
-Redraws the view for the currently active component. Use [`m.mount()`](mithril.mount.md) or [`m.route()`](mithril.route.md) to activate a component.
+Redraws the view. Use [`m.mount()`](mithril.mount.md) or [`m.route()`](mithril.route.md) to activate a component.
 
 Calling `m.redraw` triggers a redraw regardless of whether AJAX requests (and other asynchronous services) are completed. Therefore, you should ensure that templates have null checks in place to account for the possibility of variables being uninitialized when the forced redraw occurs.
 


### PR DESCRIPTION
It seems this condition is put here to reassure users that redrawing in a given route state will not draw the views of components for other routes, but it's difficult to imagine how somebody might worry that might happen.

As it is, people end up believing that redraw acts per-component, which is highly misleading in a situation where there are nested components or multiple mount points, and the call to redraw is invoked within one of those components.