### PR TITLE
Empty attributes. Fixes #971

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -96,7 +96,7 @@
 				classes.push(match[2])
 			} else if (match[3][0] === "[") {
 				var pair = /\[(.+?)(?:=("|'|)(.*?)\2)?\]/.exec(match[3])
-				cell.attrs[pair[1]] = pair[3] || (pair[2] ? "" : true)
+				cell.attrs[pair[1]] = pair[3] || (pair[2] ? "" : "")
 			}
 		}
 

--- a/mithril.js
+++ b/mithril.js
@@ -96,7 +96,7 @@
 				classes.push(match[2])
 			} else if (match[3][0] === "[") {
 				var pair = /\[(.+?)(?:=("|'|)(.*?)\2)?\]/.exec(match[3])
-				cell.attrs[pair[1]] = pair[3] || (pair[2] ? "" : "")
+				cell.attrs[pair[1]] = pair[3] || ""
 			}
 		}
 

--- a/test/mithril.js
+++ b/test/mithril.js
@@ -37,6 +37,10 @@ describe("m()", function () {
 		expect(m("[title=bar]")).to.have.deep.property("attrs.title", "bar")
 	})
 
+	it("sets attr without a value as an empty string", function () {
+		expect(m("[empty]")).to.have.deep.property("attrs.empty", "")
+	})
+
 	it("sets correct single quoted attr", function () {
 		expect(m("[title=\'bar\']")).to.have.deep.property("attrs.title", "bar")
 	})

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -11,6 +11,7 @@
 	test(function () { return m(".foo").attrs.className === "foo" })
 	test(function () { return m("[title=bar]").tag === "div" })
 	test(function () { return m("[title=bar]").attrs.title === "bar" })
+	test(function () { return m("[empty]").attrs.empty === "" })
 	test(function () { return m("[title=\'bar\']").attrs.title === "bar" })
 	test(function () { return m("[title=\"bar\"]").attrs.title === "bar" })
 	test(function () { return m("div", "test").children[0] === "test" })


### PR DESCRIPTION
An empty attribute in the selector string is equivalent to an attribute with an empty string, as per [HTML spec](https://www.w3.org/TR/html-markup/syntax.html#syntax-attr-empty). [Here's a test case showing how the browser parses static HTML with an empty attribute](https://jsfiddle.net/barney/q70xx9du/).