### PR TITLE
Allow ajax options to specify an additional onreadystatechange function

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -2011,6 +2011,10 @@
 					options.onerror({type: "error", target: xhr})
 				}
 			}
+
+			if (isFunction(options.onreadystatechange)) {
+				options.onreadystatechange()
+			}
 		}
 
 		if (options.serialize === JSON.stringify &&


### PR DESCRIPTION
Hi, 

I've needed to set a hook on the onreadystatechange function and I've added the ability to define it on the ajax options.

I needed this because I would pass some information using cookies that I want to remove as soon as possible:

```javascript
rbbt.ajax = function(params){
  if (undefined === params.method) params.method = "GET"
  if (rbbt.proxy && params.url.indexOf('//') < 0 && params.url.indexOf('/') == 0){
    params.url = rbbt.proxy + params.url
  }else{
    params.config = function(xhr, options){ xhr.setRequestHeader( "X-Requested-With", "XMLHttpRequest"); return xhr; }
  }

  if (params.cookies) {
    forHash(params.cookies, function(k,v){ rbbt.set_cookie(k,v) })

    params.onreadystatechange = function(){
      if (params.cookies){
        forHash(params.cookies, function(k,v){rbbt.remove_cookie(k)})
        params.cookies = undefined
      }
    }

  }

  return m.request(params)
}
```
I totally understand if you don't think this is a good idea. I would also appreciate any advice on how to solve my problem better if possible
