### PR TITLE
Remove redundant generics, improve accuracy and completeness of types

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -534,6 +534,14 @@ declare namespace Mithril {
 	}
 
 	/**
+	 * This covers https://github.com/lhorie/mithril.js/issues/914
+	 */
+	interface ControllerConstructor<T> {
+		(...args: any[]): T;
+		new (...args: any[]): T;
+	}
+
+	/**
 	* This represents a Mithril component.
 	*
 	* @see m
@@ -546,7 +554,7 @@ declare namespace Mithril {
 		* @see m
 		* @see m.component
 		*/
-		controller?: ((...args: any[]) => T) | (new (...args: any[]) => T);
+		controller?: ControllerConstructor<T>;
 
 		/**
 		* Creates a view out of virtual elements.


### PR DESCRIPTION
Some TypeScript simplification and improvement. Much of this was simply removing code that added no value.

Other things I did:

1. `m.redraw.strategy` is now declared as an `m.prop()`.
2. `m.redraw.strategy` now only accepts specific strings as input.
3. `m.request` now only accepts the documented methods as methods.
4. `m.render`, etc. now accept nested arrays.
5. Added `m.route.param()`, which was documented, but absent from the typings.
6. `SubtreeDirective` now has its own type.
7. Many of the overloads were simplified and combined.
8. `m.route.{build,parse}QueryString now deal with string literals (instead of `String`s)

/cc @lhorie @labEG