### PR TITLE
Fixes issue 1006

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -326,6 +326,10 @@
 		var guid = 0
 		forKeys(data, function () {
 			forEach(data, function (attrs) {
+				if (isObject(attrs)) {
+					attrs.attrs = attrs.attrs || {}
+				}
+
 				if ((attrs = attrs && attrs.attrs) && attrs.key == null) {
 					attrs.key = "__mithril__" + guid++
 				}


### PR DESCRIPTION
In some cases when using precompiled templates, `buildArrayKeys` may receive element without defined attrs (`{tag: 'div', children: 'i have no attrs'}`) and a key would not be generated for such elements.
As a result it may lead to unexpected behavior(https://jsfiddle.net/pka3at9y/ — click `add` button), like described in issue #1006 

PR adds a check on `attrs` property existing and defines `attrs` as empty object if needed