### PR TITLE
fix finding current target parent link in routeUnobtrusive

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1706,14 +1706,14 @@
 		var currentTarget = e.currentTarget || e.srcElement
 		var args
 
+		while (currentTarget && !currentTarget.href) {
+			currentTarget = currentTarget.parentNode
+		}
+
 		if (m.route.mode === "pathname" && currentTarget.search) {
 			args = parseQueryString(currentTarget.search.slice(1))
 		} else {
 			args = {}
-		}
-
-		while (currentTarget && !/a/i.test(currentTarget.nodeName)) {
-			currentTarget = currentTarget.parentNode
 		}
 
 		// clear pendingRequests because we want an immediate route change


### PR DESCRIPTION
It seems the logic is to find parent link... what is done in the commit:
- move finding current target parent link before parsing query string
- fix too loose regexp that was matching any node withe an 'a' in its name (table, area,acronym, etc.)
