### PR TITLE
Add typings to distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-.idea/

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -3,7 +3,7 @@
 /**
 * This is the module containing all the types/declarations/etc. for Mithril
 */
-declare namespace Mithril {
+export declare namespace Mithril {
 	interface ChildArray extends Array<Children> {}
 	type Children = Child | ChildArray;
 	type Child = string | VirtualElement | Component<Controller>;
@@ -851,4 +851,6 @@ declare namespace Mithril {
 	}
 }
 
-export const m: Mithril.Static;
+export declare const m: Mithril.Static;
+
+export default m;

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -851,8 +851,4 @@ declare namespace Mithril {
 	}
 }
 
-declare const m: Mithril.Static;
-
-declare module "mithril" {
-    export = m;
-}
+export const m: Mithril.Static;

--- a/mithril.js
+++ b/mithril.js
@@ -4,7 +4,7 @@
 	var m = factory(global)
 	if (typeof module === "object" && module != null && module.exports) {
 		module.exports = m
-        module.exports.m = m
+		module.exports.m = m
 	} else if (typeof define === "function" && define.amd) {
 		define(function () { return m })
 	} else {

--- a/mithril.js
+++ b/mithril.js
@@ -4,6 +4,7 @@
 	var m = factory(global)
 	if (typeof module === "object" && module != null && module.exports) {
 		module.exports = m
+        module.exports.m = m
 	} else if (typeof define === "function" && define.amd) {
 		define(function () { return m })
 	} else {

--- a/mithril.js
+++ b/mithril.js
@@ -4,9 +4,14 @@
 	var m = factory(global)
 	if (typeof module === "object" && module != null && module.exports) {
 		module.exports = m
+		module.exports.default = m
 		module.exports.m = m
 	} else if (typeof define === "function" && define.amd) {
-		define(function () { return m })
+		define(function () {
+			m.default = m
+			m.m = m
+			return m
+		})
 	} else {
 		global.m = m
 	}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "grunt lint test"
   },
   "main": "mithril.js",
+  "typings": "mithril.d.ts",
   "devDependencies": {
     "chai": "^3.4.0",
     "eslint": "^1.7.3",


### PR DESCRIPTION
Add typings to distributions. Please not ignore typings on npm publishing.
Now not needed make including typings separately from TSD or Typings.js. All what you need just make import from you code and typing will by work automatically.

``` typescript
import {m, Mithril} from 'mithril';
```

Connection typings as 'ambient' typings also working.

On others JS programmers also will by work autocomplete with help info.

PS: also add IDEA project files to gitignore
