### PR TITLE
Traceur Support

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -10,7 +10,7 @@
 		global.m = m
 	}
 	/* eslint-enable no-undef */
-})(typeof window !== "undefined" ? window : {}, function (global, undefined) { // eslint-disable-line
+})(typeof window !== "undefined" ? window : this, function (global, undefined) { // eslint-disable-line
 	"use strict"
 
 	m.version = function () {


### PR DESCRIPTION
```
// code-that-calls-m.js
console.log('abc', m('a'));
```
With v0.2.3, running the following:
`traceur --script mithril-v0.2.3.js code-that-calls-m.js`
Results in:
`ModuleEvaluationError: m is not defined`
Expected result should be:
`abc { tag: 'a', attrs: {}, children: [] }`