### PR TITLE
Add <body> tag to Getting Started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,12 +22,14 @@ Once you have a [copy of Mithril](installation.md), getting started is surprisin
 <!doctype html>
 <title>Todo app</title>
 <script src="mithril.min.js"></script>
+<body>
 <script>
 //app goes here
 </script>
+</body>
 ```
 
-Yes, this is valid HTML 5! According to the specs, the `<html>`, `<head>` and `<body>` tags can be omitted, but their respective DOM elements will still be there implicitly when a browser renders that markup.
+Yes, this is valid HTML 5! According to the specs, the `<html>` and `<head>` tags can be omitted, but their respective DOM elements will still be there implicitly when a browser renders that markup.
 
 ---
 
@@ -426,6 +428,7 @@ Here's the application code in its entirety:
 ```markup
 <!doctype html>
 <script src="mithril.min.js"></script>
+<body>
 <script>
 //this application only has one component: todo
 var todo = {};
@@ -492,6 +495,7 @@ todo.view = function() {
 //initialize the application
 m.mount(document.body, {controller: todo.controller, view: todo.view});
 </script>
+</body>
 ```
 
 This example is also available as a [jsFiddle](http://jsfiddle.net/fbgypzbr/16/).


### PR DESCRIPTION
A minor continuation of #1023. This makes the code on the Summary section a working single-file application.

Without the `<body>` tag the code failed with "Error: Please ensure the DOM element exists before rendering a template into it" because the `<script>` containing the application was inserted and run on the `<head>`, before `document.body` is created.