### PR TITLE
correct index

### DIFF
--- a/examples/todomvc/todomvc.js
+++ b/examples/todomvc/todomvc.js
@@ -39,7 +39,7 @@ function countRemaining() {
 }
 function clear() {
 	for (var i = 0; i < todos.length; i++) {
-		if (todos[i].completed) destroy(todos[i])
+		if (todos[i].completed) destroy(todos[i--])
 	}
 }
 


### PR DESCRIPTION
```todos.splice(index, 1)``` in destroy makes the elements shift; therefor loops index has to be aligned has to be corrected