### PR TITLE
Force redirect when pushState encounters an error

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1617,8 +1617,16 @@
 				var method = replaceHistory ? "replaceState" : "pushState"
 				computePreRedrawHook = setScroll
 				computePostRedrawHook = function () {
-					global.history[method](null, $document.title,
-						modes[m.route.mode] + currentRoute)
+					try {
+						global.history[method](null, $document.title,
+							modes[m.route.mode] + currentRoute)
+					} catch (err) {
+						// In the event of a pushState or replaceState failure,
+						// fallback to a standard redirect. This is specifically
+						// to address a Safari security error when attempting to
+						// call pushState more than 100 times.
+						$location[m.route.mode] = currentRoute
+					}
 				}
 				redirect(modes[m.route.mode] + currentRoute)
 			} else {


### PR DESCRIPTION
Version 9.1 of Safari allows a maximum of 100 calls to pushState. Subsequent calls to pushState throw a SecurityError: DOM Exception 18: An attempt was made to break through the security policy of the user agent.

This jsfiddle shows the error in action when using Safari v9.1:

https://jsfiddle.net/j1sxxLwy/

In Safari Technology Preview v9.1.1, the implementation is improved to only cap pushState to 100 calls in a 30 second period. This jsfiddle shows that the error is not encountered when there is a delay between pushState calls in Safari Technology Preview v9.1.1, however it is still present in Safari v9.1:

https://jsfiddle.net/885yfab6/

So it seems that in future versions of Safari the pushState check will be improved to only prevent malicious or buggy code from executing. I've provided a fix in the meantime since I'm unsure of the timeline for that enhancement. However, I'd be the first to admit that it's not necessarily the right way to fix this or if a fix even belongs in mithril. Really more interested in starting a discussion on the best way to handle this error, since it seems like other developers using mithril may run into this issue in their applications.