### PR TITLE
Correctly inject script tags via m.trust in Safari (Fix #1045)

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1176,7 +1176,39 @@
 				$document.createRange().createContextualFragment(data))
 		} catch (e) {
 			parentElement.insertAdjacentHTML("beforeend", data)
+			replaceScriptNodes(parentElement)
 		}
+	}
+
+	// Replace script tags inside given DOM element with executable ones.
+	// Will also check children recursively and replace any found script
+	// tags in same manner.
+	function replaceScriptNodes(node) {
+		if (node.tagName === "SCRIPT") {
+			node.parentNode.replaceChild(buildExecutableNode(node), node)
+		} else {
+			var children = node.childNodes
+			if (children && children.length) {
+				for (var i = 0; i < children.length; i++) {
+					replaceScriptNodes(children[i])
+				}
+			}
+		}
+
+		return node
+	}
+
+	// Replace script element with one whose contents are executable.
+	function buildExecutableNode(node){
+		var scriptEl = document.createElement("script")
+		var attrs = node.attributes
+
+		for (var i = 0; i < attrs.length; i++) {
+			scriptEl.setAttribute(attrs[i].name, attrs[i].value)
+		}
+
+		scriptEl.text = node.innerHTML
+		return scriptEl
 	}
 
 	function injectHTML(parentElement, index, data) {

--- a/test/mithril.trust.js
+++ b/test/mithril.trust.js
@@ -65,5 +65,21 @@ describe("m.trust()", function () {
 			expect(root.innerHTML)
 				.to.equal("<div><p>&amp;copy;</p><p>©</p>©</div>")
 		})
+
+		// https://github.com/lhorie/mithril.js/issues/1045
+		it("correctly injects script tags and executes them", function () {
+			var HTMLString =
+			"<script>document.getElementById('root').innerText='After'</script>"
+			var root = document.createElement("div")
+			var child = document.createElement("div")
+			root.id = "root"
+			root.innerText = "Before"
+			root.appendChild(child)
+			document.body.appendChild(root)
+
+			m.render(child, m.trust(HTMLString))
+
+			expect(root.innerText).to.equal("After")
+		})
 	})
 })


### PR DESCRIPTION
Details of problem are described on the issue page at https://github.com/lhorie/mithril.js/issues/1045

Adds a function `replaceScriptNodes` along with helper `buildExecutableNode` that check injected HTML for `<script>...</script>` nodes, and replace their contents with executable elements.

This function will only be called (AFAIK...) in Safari, since it throws on invocation of `createContextualFragment`, leading to the fallback onto `insertAdjacentHTML`.

Any feedback is welcome, including variable naming, whether the test should be in a different location, etc.

Thanks in advance! 👍 