### PR TITLE
Filter out util dirs from istanbul coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "node bundler/bundler",
 		"test": "node ospec/bin/ospec",
-		"cover": "istanbul cover --print both ospec/bin/ospec"
+		"cover": "istanbul cover --print both -x \"**/ospec/**\" -x \"**/test-utils/**\" ospec/bin/ospec"
 	},
 	"author": "Leo Horie",
 	"license": "MIT",


### PR DESCRIPTION
Removing the noise seems pretty useful, and while it makes the CLI a bit ugly I prefer not littering the root of the repo w/ too many tiny config files.