### PR TITLE
Linebreaks are hard, spacing isn't

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,10 +67,12 @@ module.exports = {
         "init-declarations": "off",
         "jsx-quotes": "error",
         "key-spacing": "error",
-        "keyword-spacing": "off",
-        "linebreak-style": [
+        "keyword-spacing": [
             "error",
-            "unix"
+            {
+                "before": true,
+                "after": true
+            }
         ],
         "lines-around-comment": "error",
         "max-depth": "off",


### PR DESCRIPTION
Because linebreaks are affected by git's `core.autocrlf` rule and I don't feel like adding a `.gitattributes` file yet.