### PR TITLE
JSON.stringify(m.prop(x)) use x.toJSON method when possible

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1331,6 +1331,7 @@
 		}
 
 		prop.toJSON = function () {
+			if (store && isFunction(store.toJSON)) return store.toJSON()
 			return store
 		}
 

--- a/test/mithril.prop.js
+++ b/test/mithril.prop.js
@@ -42,6 +42,22 @@ describe("m.prop()", function () {
 		expect(JSON.stringify(obj)).to.equal('{"prop":"test"}')
 	})
 
+	it("correctly stringifies Date", function () {
+		var prop = m.prop(new Date(999))
+		expect(JSON.stringify(prop)).to.equal('"1970-01-01T00:00:00.999Z"')
+	})
+
+	it("correctly stringifies object with toJSON method", function () {
+		function Thing(name) {
+			this.name = name
+		}
+		Thing.prototype.toJSON = function() {
+			return {kind: 'Thing', name: this.name}
+		}
+		var banana = m.prop(new Thing("bannana"))
+		expect(JSON.stringify(banana)).to.equal('{"kind":"Thing","name":"bannana"}')
+	})
+
 	it("correctly wraps Mithril promises", function () {
 		var defer = m.deferred()
 		var prop = m.prop(defer.promise)


### PR DESCRIPTION
When JSON serializing `m.prop`, check if wrapped object does define `toJSON` method
and if so, return it's result.

I'm not sure how to properly test javascript code, so please check everything before.