### PR TITLE
Fixes js.org badge link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![JS.ORG](https://img.shields.io/badge/js.org-mithril-ffb400.svg?style=flat-square)](http://js.org)
+[![JS.ORG](https://img.shields.io/badge/js.org-mithril-ffb400.svg?style=flat-square)](http://mithril.js.org/)
 [![Join the chat at https://gitter.im/lhorie/mithril.js](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/lhorie/mithril.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/lhorie/mithril.js.svg?branch=master)](https://travis-ci.org/lhorie/mithril.js)
 


### PR DESCRIPTION
I believe js.org badge goes to the wrong location. So I changed it from *js.org* to *mithril.js.org/*.