### PR TITLE
Sounder approach to parsing CSS attribulte selectors

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -82,11 +82,25 @@
 	 * Which describes a DOM node
 	 */
 
+	var quoteTable = {
+		"'": '"',
+		"\\'": "'",
+		'\\\\': '\\\\',
+		'\\"': '\\"',
+		'"': '\\"'
+	}
+
+	function convertQuote(q) {return quoteTable[q]}
+
+	function parseString(str) {
+		if (str.charAt(0) === "'") str = str.replace(/^'|'$|\\[\\"']|"/g, convertQuote)
+		return JSON.parse(str)
+	}
+
 	function parseTagAttrs(cell, tag) {
 		var classes = []
-		var parser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[.+?\])/g
+		var parser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[.*?(?:=(?:"(?:\\[\s\S]|[^"\n])*"|'(?:\\[\s\S]|[^'\n])*'|.*?))?\])/g
 		var match
-
 		while ((match = parser.exec(tag))) {
 			if (match[1] === "" && match[2]) {
 				cell.tag = match[2]
@@ -95,8 +109,8 @@
 			} else if (match[1] === ".") {
 				classes.push(match[2])
 			} else if (match[3][0] === "[") {
-				var pair = /\[(.+?)(?:=("|'|)(.*?)\2)?\]/.exec(match[3])
-				cell.attrs[pair[1]] = pair[3] || ""
+				var pair = /\[(.+?)(?:=(?:("(?:\\[\s\S]|[^"\n])*"|'(?:\\[\s\S]|[^'\n])*')|("|'|)(.*?)\3))?\]/.exec(match[3])
+				cell.attrs[pair[1]] = pair[2] ? parseString(pair[2]) : pair[4] || ""
 			}
 		}
 

--- a/test/mithril.js
+++ b/test/mithril.js
@@ -37,16 +37,48 @@ describe("m()", function () {
 		expect(m("[title=bar]")).to.have.deep.property("attrs.title", "bar")
 	})
 
+	it("sets correct unquoted attr with unicode characters", function () {
+		expect(m("[title=bö💥]")).to.have.deep.property("attrs.title", "bö💥")
+	})
+
 	it("sets attr without a value as an empty string", function () {
 		expect(m("[empty]")).to.have.deep.property("attrs.empty", "")
 	})
 
 	it("sets correct single quoted attr", function () {
-		expect(m("[title=\'bar\']")).to.have.deep.property("attrs.title", "bar")
+		expect(m("[title='bar']")).to.have.deep.property("attrs.title", "bar")
+	})
+
+	it("sets correct single quoted attr with old-style embedded single quote", function () {
+		expect(m("[title='b'ar']")).to.have.deep.property("attrs.title", "b'ar")
+	})
+
+	it("sets correct single quoted attr with an embedded single quote", function () {
+		expect(m("[title='b\\'ar']")).to.have.deep.property("attrs.title", "b'ar")
+	})
+
+	it("sets correct single quoted attr with an embedded escape sequences and quotes", function () {
+		expect(m("[title='b\\\\\\'\\\"\\\\\"ar']")).to.have.deep.property("attrs.title", "b\\'\"\\\"ar")
+	})
+
+	it("sets correct single quoted attr with an embedded closing bracket", function () {
+		expect(m("[title='b]ar']")).to.have.deep.property("attrs.title", "b]ar")
 	})
 
 	it("sets correct double quoted attr", function () {
 		expect(m("[title=\"bar\"]")).to.have.deep.property("attrs.title", "bar")
+	})
+
+	it("sets correct double quoted attr with old-style embedded double quotes", function () {
+		expect(m("[title=\"b\"a\"r\"]")).to.have.deep.property("attrs.title", "b\"a\"r")
+	})
+
+	it("sets correct double quoted attr with an embedded double quote and closing bracket", function () {
+		expect(m("[title=\"b\\\"]ar\"]")).to.have.deep.property("attrs.title", "b\"]ar")
+	})
+
+	it("sets correct double quoted attr with an embedded closing bracket", function () {
+		expect(m("[title=\"b]ar\"]")).to.have.deep.property("attrs.title", "b]ar")
 	})
 
 	it("sets correct children with 1 string arg", function () {


### PR DESCRIPTION
One way to address #1080. Breaks BW compat though, since `m('[foo="b"a"r"]')` no longer sets `attrs.foo` to `'b"a"r'`.

If you agree with the approach, this also probably mandates a docs update... Or maybe we keep this for the rewrite?