### PR TITLE
Render booleans as empty strings

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -188,7 +188,7 @@
 		// value of Console.log in some versions of Firefox (behavior depends on
 		// version)
 		try {
-			if (data != null && data.toString() != null) return data
+			if (typeof data !== "boolean" && data != null && data.toString() != null) return data
 		} catch (e) {
 			// silently ignore errors
 		}

--- a/test/mithril.render.js
+++ b/test/mithril.render.js
@@ -57,6 +57,24 @@ describe("m.render()", function () {
 		expect(root.childNodes[0].childNodes[0].nodeValue).to.equal("")
 	})
 
+	it("renders `null` body to empty string", function () {
+		var root = mock.document.createElement("div")
+		m.render(root, m("div", [null]))
+		expect(root.childNodes[0].childNodes[0].nodeValue).to.equal("")
+	})
+
+	it("renders `true` body to empty string", function () {
+		var root = mock.document.createElement("div")
+		m.render(root, m("div", [true]))
+		expect(root.childNodes[0].childNodes[0].nodeValue).to.equal("")
+	})
+
+	it("renders `false` body to empty string", function () {
+		var root = mock.document.createElement("div")
+		m.render(root, m("div", [false]))
+		expect(root.childNodes[0].childNodes[0].nodeValue).to.equal("")
+	})
+
 	it("uses the W3C URI as default namespace for SVG children", function () {
 		var root = mock.document.createElement("div")
 		m.render(root, m("svg", [m("g")]))

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -11,7 +11,7 @@
 	test(function () { return m(".foo").attrs.className === "foo" })
 	test(function () { return m("[title=bar]").tag === "div" })
 	test(function () { return m("[title=bar]").attrs.title === "bar" })
-	test(function () { return m("[empty]").attrs.empty === "" })
+	test(function () { return m("[empty]").attrs.empty === true })
 	test(function () { return m("[title=\'bar\']").attrs.title === "bar" })
 	test(function () { return m("[title=\"bar\"]").attrs.title === "bar" })
 	test(function () { return m("div", "test").children[0] === "test" })
@@ -1747,6 +1747,24 @@
 	test(function () {
 		var root = mock.document.createElement("div")
 		m.render(root, m("div", [undefined]))
+		return root.childNodes[0].childNodes[0].nodeValue === ""
+	})
+
+	test(function () {
+		var root = mock.document.createElement("div")
+		m.render(root, m("div", [null]))
+		return root.childNodes[0].childNodes[0].nodeValue === ""
+	})
+
+	test(function () {
+		var root = mock.document.createElement("div")
+		m.render(root, m("div", [true]))
+		return root.childNodes[0].childNodes[0].nodeValue === ""
+	})
+
+	test(function () {
+		var root = mock.document.createElement("div")
+		m.render(root, m("div", [false]))
 		return root.childNodes[0].childNodes[0].nodeValue === ""
 	})
 


### PR DESCRIPTION
This implements https://github.com/lhorie/mithril.js/issues/1014 and incidentally fixes a broken test in the old test suite. I added tests to both suites since in gitter it was mentioned we can't delete the old suite yet.

