### PR TITLE
Add migration docs for m.route.prefix

### DIFF
--- a/docs/v1.x-migration.md
+++ b/docs/v1.x-migration.md
@@ -11,6 +11,7 @@ Migrating from `v0.2.x` to `v1.x`
 - [`m.route` and anchor tags](#mroute-and-anchor-tags)
 - [Reading/writing the current route](#readingwriting-the-current-route)
 - [Accessing route params](#accessing-route-params)
+- [Setting route prefix](#setting-route-prefix)
 
 ## `config` function
 
@@ -167,13 +168,13 @@ In `v0.2.x` you could pass components as the second argument of `m()` w/o any wr
 ### `v0.2.x`
 
 ```js
-m("div", <component>);
+m("div", component);
 ```
 
 ### `v1.x`
 
 ```js
-m("div", m(<component>));
+m("div", m(component));
 ```
 
 ## `m.route()` and anchor tags
@@ -253,4 +254,20 @@ m.route(document.body, "/booga", {
         }
     }
 });
+```
+
+## Setting route prefix
+
+In `v0.2.x` the route prefix could be set by assigning a string of `"pathname"`, `"hash"`, or `"search"` to `m.route.mode`. In `v1.x` this has been replaced by `m.route.prefix` which is a setter function. Passing it an empty string is analogous to using pathname mode. Other options include passing `"#"` for hash and `"?"` for search.
+
+### `v0.2.x`
+
+```js
+m.route.mode = "pathname";
+```
+
+### `v1.x`
+
+```js
+m.route.prefix("");
 ```


### PR DESCRIPTION
Also made a change in the documentation around passing components to `m()`. Before, the syntax that was used made it look like jsx, which could easily have been misinterpreted. Since `component` is defined in the docs just prior, I don't think we need any special syntax to indicate that it might have been a placeholder value.