### PR TITLE
Fix #1091 Value on select tag not set when options are changed

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -727,13 +727,6 @@
 			cached.children.nodes = []
 		}
 
-		// edge case: setting value on <select> doesn't work before children
-		// exist, so set it again after children have been created
-		if (data.tag === "select" && "value" in data.attrs) {
-			setAttributes(node, data.tag, {value: data.attrs.value}, {},
-				namespace)
-		}
-
 		return cached
 	}
 
@@ -886,6 +879,13 @@
 				views,
 				configs,
 				controllers)
+		}
+
+		// edge case: setting value on <select> doesn't work before children
+		// exist, so set it again after children have been created/updated
+		if (data.tag === "select" && "value" in data.attrs) {
+			setAttributes(node, data.tag, {value: data.attrs.value}, {},
+				namespace)
 		}
 
 		if (!isNew && shouldReattach === true && node != null) {

--- a/test/mithril.render.js
+++ b/test/mithril.render.js
@@ -1567,5 +1567,15 @@ describe("m.render()", function () {
 			expect(root.childNodes[0].innerHTML)
 				.to.equal('<option value="">aaa</option>')
 		})
+
+		it("sets correct <select> value", function () {
+			var root = document.createElement("div")
+			m.render(root, m("select", {value: "b"}, [
+				m("option", {value: "a"}, "aaa"),
+				m("option", {value: "b"}, "bbb")
+			]))
+			// This works only if select value is set after its options exist.
+			expect(root.childNodes[0].value).to.equal("b")
+		})
 	})
 })


### PR DESCRIPTION
This PR fixes #1091.

Basically, the \<select\>'s `value` weird behaviour was already considered on Mithril's code, but only for the case when the \<select\> node was initially created. I just moved that edge case code so it's also called when the node is being recycled, in case its \<option\>s change.

It seems to work fine, but i couldn't manage to do a regression test case to exercise this. The test case would need to use a real DOM, but also do a diff redraw. Something like this is enough for triggering the old buggy behaviour on browsers, and works well with this patch:

```javascript
var ctrl = m.mount(document.body, {
  controller: function () {
    this.value = "foo"
  },
  view: function (ctrl) {
    return m("select", {value: ctrl.value}, [
      m("option", {value: ctrl.value}, ctrl.value)
    ])
  }
})

ctrl.value = "bar"
m.redraw()
```

But i couldn't translate that into a test that would both fail before the patch and pass after it. Any ideas? :sweat_smile: 

That being said, i did add a test to check that the \<select\> value is correctly set when the node is initially created :smiley_cat: 