### PR TITLE
Add definition file to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mithril.min.js",
     "mithril.min.js.map",
     "mithril.js",
+    "mithril.d.js",
     "README.*"
   ]
 }


### PR DESCRIPTION
Fixes #1107 

(I also had to fix the syntax.)

@lhorie BTW, TypeScript *does* find definition files under `node_modules` now, so it's best to upload it to npm now.

As a side effect, nobody needs to worry about other versions.