### PR TITLE
Remove unloaders when root element is removed

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1473,6 +1473,7 @@
 		components.splice(index, 1)
 		reset(root)
 		nodeCache.splice(getCellCacheKey(root), 1)
+		unloaders = []
 	}
 
 	var redrawing = false

--- a/test/mithril.route.js
+++ b/test/mithril.route.js
@@ -102,8 +102,7 @@ describe("m.route()", function () {
 		expect(route2).to.equal("/test13")
 	})
 
-	// FIXME: this causes others to fail
-	xdit("skips route change if component ctrl.onunload calls preventDefault", function (root) { // eslint-disable-line
+	dit("skips route change if component ctrl.onunload calls preventDefault", function (root) { // eslint-disable-line
 		mode("search")
 		var spy = sinon.spy()
 
@@ -130,68 +129,7 @@ describe("m.route()", function () {
 		expect(spy).to.not.have.been.called
 	})
 
-	// FIXME: this causes others to fail
-	xdit("skips route change if subcomponent ctrl.onunload calls preventDefault", function (root) { // eslint-disable-line
-		mode("search")
-
-		var spy = sinon.spy()
-
-		var subsub = {
-			controller: function () {
-				this.onunload = function (e) { e.preventDefault() }
-			},
-			view: function () {
-				return m("div")
-			}
-		}
-
-		var sub = pure(function () { return subsub })
-
-		route(root, "/a", {
-			"/a": pure(function () { return sub }),
-
-			"/b": {
-				controller: spy,
-				view: noop
-			}
-		})
-
-		route("/b")
-
-		expect(spy).to.not.have.been.called
-	})
-
-	// FIXME: this causes others to fail
-	xdit("skips route change if non-curried component ctrl.onunload calls preventDefault", function (root) { // eslint-disable-line
-		mode("search")
-
-		var spy = sinon.spy()
-
-		var sub = {
-			controller: function () {
-				this.onunload = function (e) { e.preventDefault() }
-			},
-			view: function () {
-				return m("div")
-			}
-		}
-
-		route(root, "/a", {
-			"/a": pure(function () { return sub }),
-
-			"/b": {
-				controller: spy,
-				view: noop
-			}
-		})
-
-		route("/b")
-
-		expect(spy).to.not.have.been.called
-	})
-
-	// FIXME: this causes others to fail
-	xdit("skips route change if non-curried subcomponent ctrl.onunload calls preventDefault", function (root) { // eslint-disable-line
+	dit("skips route change if subcomponent ctrl.onunload calls preventDefault", function (root) { // eslint-disable-line
 		mode("search")
 
 		var spy = sinon.spy()


### PR DESCRIPTION
Hi! I stumbled upon this when trying to make a test for #1091 work.

Please take into account that i'm not familiarized at all with the Mithril codebase, so this proposed "fix" for the pending tests could totally be a nonsensical screwup!  :sweat_smile: 

---

When a controller calls preventDefault on its onunload method, it prevents the current root element from being unmounted via a route change. But it does not prevent it from being unmounted via m.mount(root, null). In that case, the root element is unmounted, but any unloaders that it had keep hanging on the `unloaders` array, and that prevented any future m.mount(root, component) calls from succeeding. This is what was happening on the pending route() tests.

The fix is pretty simple: just reset the `unloaders` array when removing the root element, just like it's done when no unloader calls preventDefault.

Also, 2 of the 4 pending tests were removed because they were identical to the other 2.