### PR TITLE
Push route to history stack, when using parameters #1124

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1659,7 +1659,7 @@
 
 			var replaceHistory =
 				(arguments.length === 3 ? arg2 : arg1) === true ||
-				oldRoute === root
+				oldRoute === currentRoute
 
 			if (global.history.pushState) {
 				var method = replaceHistory ? "replaceState" : "pushState"


### PR DESCRIPTION
Bugfix for issue #1124
The condition has been changed, which is deciding to push the a route to history stack.
I think, it is necessary to compare the old route with the current route, instead of old route with root (without parameters).