### PR TITLE
Add m.prop.sync

### DIFF
--- a/docs/v1.x-migration.md
+++ b/docs/v1.x-migration.md
@@ -11,6 +11,7 @@
 - [Reading/writing the current route](#readingwriting-the-current-route)
 - [Accessing route params](#accessing-route-params)
 - [Setting route prefix](#setting-route-prefix)
+- [m.request](#mrequest)
 
 ## `config` function
 
@@ -269,4 +270,58 @@ m.route.mode = "pathname";
 
 ```js
 m.route.prefix("");
+```
+
+## m.request
+
+[m.request](request.md) now returns an [m.prop stream](prop.md) instead of a promise. The main difference is you'll have to use `.run` to get similar functionality as a promise's `.then`:
+
+### `v0.2.x`
+
+```js
+m.request({ method: 'GET', url: 'https://api.github.com/' })
+    .then(function (responseBody) {
+        return m.request({ method: 'GET', url: responseBody.emojis_url });
+    })
+    .then(function (emojis) {
+        console.log("+1 url:", emojis['+1']);
+    });
+```
+
+### `v1.x`
+
+```js
+m.request({ method: 'GET', url: 'https://api.github.com/' })
+    .run(function (responseBody) {
+        return m.request({ method: 'GET', url: responseBody.emojis_url });
+    })
+    .run(function (emojis) {
+        console.log("+1 url:", emojis['+1']);
+    });
+```
+
+The equivalent of `m.sync` is now `m.prop.sync`:
+
+### `v0.2.x`
+
+```js
+m.sync([
+    m.request({ method: 'GET', url: 'https://api.github.com/users/lhorie' }),
+    m.request({ method: 'GET', url: 'https://api.github.com/users/isiahmeadows' }),
+])
+    .then(function (users) {
+        console.log("Contributors:", users[0].name, "and", users[1].name);
+    });
+```
+
+### `v1.x`
+
+```js
+m.prop.sync([
+    m.request({ method: 'GET', url: 'https://api.github.com/users/lhorie' }),
+    m.request({ method: 'GET', url: 'https://api.github.com/users/isiahmeadows' }),
+])
+    .run(function (users) {
+        console.log("Contributors:", users[0].name, "and", users[1].name);
+    });
 ```

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ m.route = require("./api/router")(window, renderService, redrawService)
 m.mount = require("./api/mount")(renderService, redrawService)
 m.trust = require("./render/trust")
 m.prop = Stream.stream
+m.prop.sync = Stream.sync
 m.prop.combine = Stream.combine
 m.prop.reject = Stream.reject
 m.prop.HALT = Stream.HALT

--- a/util/stream.js
+++ b/util/stream.js
@@ -174,4 +174,12 @@ function reject(e) {
 	return stream
 }
 
-module.exports = {stream: createStream, combine: combine, reject: reject, HALT: HALT}
+function sync (streams) {
+	return combine(function () {
+		return Array.prototype.slice
+			.call(arguments, 0, arguments.length-1)
+			.map(function (s) { return s() })
+	}, streams)
+}
+
+module.exports = {stream: createStream, sync: sync, combine: combine, reject: reject, HALT: HALT}

--- a/util/tests/test-stream.js
+++ b/util/tests/test-stream.js
@@ -166,6 +166,31 @@ o.spec("stream", function() {
 			o(b()).equals(undefined)
 		})
 	})
+	o.spec("sync", function() {
+		o("transforms an array of streams to an array of values", function() {
+			var all = Stream.sync([
+				Stream.stream(10),
+				Stream.stream("20"),
+				Stream.stream({ value: 30 }),
+			])
+			
+			o(all()).deepEquals([10, "20", { value: 30 }])
+		})
+		o("remains pending until all streams are active", function() {
+			var straggler = Stream.stream()
+
+			var all = Stream.sync([
+				Stream.stream(10),
+				Stream.stream("20"),
+				straggler,
+			])
+			
+			o(all()).equals(undefined)
+
+			straggler(30)
+			o(all()).deepEquals([10, "20", 30])
+		})
+	})
 	o.spec("end", function() {
 		o("end stream works", function() {
 			var stream = Stream.stream()


### PR DESCRIPTION
This is written to behave like 0.2.x's `m.sync`. Also added migration docs.