### PR TITLE
Event handlers redraw all mount points. Fix #1146

### DIFF
--- a/api/autoredraw.js
+++ b/api/autoredraw.js
@@ -6,7 +6,7 @@ module.exports = function(root, renderer, pubsub, callback) {
 	var run = throttle(callback)
 	if (renderer != null) {
 		renderer.setEventCallback(function(e) {
-			if (e.redraw !== false) run()
+			if (e.redraw !== false) pubsub.publish()
 		})
 	}
 


### PR DESCRIPTION
This fixes the [fiddle](https://jsfiddle.net/nh12t8zy/1/), but #1149 still gives an error, probably due to the fact that the second mount occurs at redraw time and redraws are batched.

I'll add a proper test later (unless someone beats me to it).

(#1146)