### PR TITLE
Per event redraw

### DIFF
--- a/api/autoredraw.js
+++ b/api/autoredraw.js
@@ -6,7 +6,8 @@ module.exports = function(root, renderer, pubsub, callback) {
 	var run = throttle(callback)
 	if (renderer != null) {
 		renderer.setEventCallback(function(e) {
-			if (e.redraw !== false) pubsub.publish()
+			if (typeof e.redraw === "function") e.redraw.call(null)
+			else if (e.redraw !== false) pubsub.publish()
 		})
 	}
 

--- a/api/tests/test-autoredraw.js
+++ b/api/tests/test-autoredraw.js
@@ -92,4 +92,29 @@ o.spec("autoredraw", function() {
 		o(spy.callCount).equals(0)
 	})
 
+	o("does redraw if e.redraw is true", function() {
+		autoredraw(root, renderer, pubsub, spy)
+
+		renderer.render(root, {tag: "div", attrs: {onclick: function(e) {e.redraw = true}}})
+
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+		root.firstChild.dispatchEvent(e)
+
+		o(spy.callCount).equals(1)
+	})
+
+	o("calls custom redraw function when provided", function() {
+		var customRedrawer = o.spy()
+		autoredraw(root, renderer, pubsub, spy)
+
+		renderer.render(root, {tag: "div", attrs: {onclick: function(e) {e.redraw = customRedrawer}}})
+
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+		root.firstChild.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+		o(customRedrawer.callCount).equals(1)
+	})
 })

--- a/docs/hyperscript.md
+++ b/docs/hyperscript.md
@@ -171,6 +171,21 @@ function doSomething(e) {
 m("div", {onclick: doSomething})
 ```
 
+
+
+By default, the full application is redrawn after running the even handler you supplied. You can prevent the redraw from occurring by setting the `redraw` property of the event (`e` in these samples) to `false`.
+
+```javascript
+function doSomethingDontRedraw(e) {
+	e.redraw = false
+	console.log(e)
+}
+```
+
+Mithril also supports per mount point redraws through a `redraw` function attached to the `root` DOM node passed to `m.mount(root, component)` and `m.route(root, defaultRoute, routes)`.
+
+To redraw a single mount point after an event, you can pass that function as `e.redraw = root.redraw`.
+
 ---
 
 ### Properties


### PR DESCRIPTION
This would allow to do things like

```JS
m('div', {onclick: function(e) {
  // do clicky things, then
  e.redraw = root.redraw
}})
```

Where `root` is the DOM node where the component has been mounted. Currently, the only alternative is a per-island redraw in a multi-island scenario. If more granular redraws like #684 were implemented, it would work as well.

The advantage over doing `e.redraw = false; root.redraw()` is that it standardizes the place where redraw is called, if, at some point, you want to run custom logic between the user-supplied event handler and the `redraw()` call.

The tests are failing because of #1156