### PR TITLE
Patch for #956: redraw trusted content with multiple nodes

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -536,6 +536,7 @@
 		}
 		cached = new data.constructor(data)
 		cached.nodes = nodes
+		cached.$trusted = data.$trusted
 		return cached
 	}
 
@@ -562,10 +563,7 @@
 		if (item.$trusted) {
 			// fix offset of next element if item was a trusted string w/ more
 			// than one html element
-			// the first clause in the regexp matches elements
-			// the second clause (after the pipe) matches text nodes
-			var match = item.match(/<[^\/]|\>\s*[^<]/g)
-			if (match != null) return match.length
+			return item.nodes.length
 		} else if (isArray(item)) {
 			return item.length
 		}

--- a/test/mithril.trust.js
+++ b/test/mithril.trust.js
@@ -81,5 +81,37 @@ describe("m.trust()", function () {
 
 			expect(root.innerText).to.equal("After")
 		})
+
+		// https://github.com/lhorie/mithril.js/issues/956
+		it("works with many and nested tags in trusted content", function () {
+			var page = {
+				names: m.prop(["John", "Paul", "George", "Ringo"]),
+				nodeString: function (name) {
+					return "<div><p>Hi </p></div><div><p>" + name + "</p></div>"
+				},
+				view: function () {
+					return m("div",
+						this.names().map(function (name) {
+							return m.trust(this.nodeString(name))
+						}, this)
+					)
+				}
+			}
+			m.render(document.body, page)
+			var root = document.body.children[0]
+			expect(root.children.length).to.equal(2 * page.names().length)
+			for (var i = 0; i < page.names().length; i++) {
+				var section = root.children[2 * i + 1]
+				expect(section.children[0].innerText).to.equal(page.names()[i])
+			}
+
+			page.names(["Jack", "Jill"])
+			m.render(document.body, page)
+			expect(root.children.length).to.equal(2 * page.names().length)
+			for (i = 0; i < page.names().length; i++) {
+				section = root.children[2 * i + 1]
+				expect(section.children[0].innerText).to.equal(page.names()[i])
+			}
+		})
 	})
 })


### PR DESCRIPTION
The regex in the current version of `getSubArrayCount()` miscounts nested elements in trusted content, leading to nodes that are inaccessible to the diffing algorithm. Additionally, text nodes lose the `$trusted` flag when cached in `reattachNodes()`, which causes `getSubArrayCount()` to default to returning 1.