### PR TITLE
Specify tab width in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ charset = utf-8
 
 [*.js]
 indent_style = tab
+indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = crlf


### PR DESCRIPTION
ESLint appears to define a tab as equivalent to four spaces, but the the lack of tab width specification in `.editorconfig` means that editors can still represent them however they wish.

This bug manifested for me because I've set tabs to be two spaces in my `.vimrc`, and I got unexpected line length errors when I ran `grunt lint`.