### PR TITLE
Unmount and cleanly refresh mount points

### DIFF
--- a/api/mount.js
+++ b/api/mount.js
@@ -1,14 +1,26 @@
 "use strict"
 
+var Vnode = require("../render/vnode")
 var coreRenderer = require("../render/render")
 var autoredraw = require("../api/autoredraw")
+var dummy = {view: function() {}}
 
 module.exports = function(renderer, pubsub) {
 	return function(root, component) {
+		pubsub.unsubscribe(root.redraw)
+
 		var run = autoredraw(root, renderer, pubsub, function() {
-			renderer.render(root, {tag: component})
+			renderer.render(
+				root,
+				Vnode(component === null ? dummy : component, undefined, undefined, undefined, undefined, undefined)
+			)
 		})
 
 		run()
+
+		if (component === null) {
+			pubsub.unsubscribe(root.redraw)
+			delete root.redraw
+		}
 	}
 }

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -32,6 +32,20 @@ o.spec("mount", function() {
 		o(root.firstChild.nodeName).equals("DIV")
 	})
 
+	o("mounting null deletes `redraw` from `root`", function() {
+		mount(root, {
+			view : function() {
+				return m("div")
+			}
+		})
+
+		o(typeof root.redraw).equals('function')
+
+		mount(root, null)
+
+		o(typeof root.redraw).equals('undefined')
+	})
+
 	o("redraws on events", function(done) {
 		var onupdate = o.spy()
 		var oninit   = o.spy()

--- a/docs/mount.md
+++ b/docs/mount.md
@@ -2,6 +2,7 @@
 
 - [API](#api)
 - [How it works](#how-it-works)
+- [Performance considerations](#performance-considerations)
 - [Differences from m.render](#differences-from-m-render)
 
 ---
@@ -13,7 +14,7 @@
 Argument    | Type                 | Required | Description
 ----------- | -------------------- | -------- | ---
 `element`   | `Element`            | Yes      | A DOM element that will be the parent node to the subtree
-`component` | `Component`          | Yes      | The [component](components.md) to be rendered
+`component` | `Component|null`     | Yes      | The [component](components.md) to be rendered. `null` unmounts the tree and cleans up internal state.
 **returns** |                      |          | Returns nothing
 
 [How to read signatures](signatures.md)
@@ -23,6 +24,18 @@ Argument    | Type                 | Required | Description
 ### How it works
 
 Similar to [`m.render()`](render.md), the `m.mount()` method takes a component and mounts a corresponding DOM tree into `element`. If `element` already has a DOM tree mounted via a previous `m.mount()` call, the component is diffed against the previous vnode tree and the existing DOM tree is modified only where needed to reflect the changes. Unchanged DOM nodes are not touched at all.
+
+#### Replace a component
+
+Running `mount(element, OtherComponent)` where `element` is a current mount point replaces the component previously mounted with `OtherComponent`.
+
+#### Unmount
+
+Using `m.mount(element, null)` on an element with a previously mounted component unmounts it and cleans up Mithril internal state. This can be useful to prevent memory leaks when removing the `root` node manually from the DOM.
+
+---
+
+### Performance considerations
 
 It may seem wasteful to generate a vnode tree on every redraw, but as it turns out, creating and comparing Javascript data structures is surprisingly cheap compared to reading and modifying the DOM.
 


### PR DESCRIPTION
This is a better version of #1169.

Passing `null` unmounts the component and removes the renderer from the `pubsub` array. 

Replacing a mounted component removes the previous renderer.

I've also added a note about mounting vnodes not working in `v1.x`.