### PR TITLE
Move the `dom.vnodes` assignement up one line.

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -518,8 +518,8 @@ module.exports = function($window) {
 
 		if (!(vnodes instanceof Array)) vnodes = [vnodes]
 		updateNodes(dom, dom.vnodes, Node.normalizeChildren(vnodes), hooks, null, undefined)
-		for (var i = 0; i < hooks.length; i++) hooks[i]()
 		dom.vnodes = vnodes
+		for (var i = 0; i < hooks.length; i++) hooks[i]()
 		if ($doc.activeElement !== active) active.focus()
 	}
 


### PR DESCRIPTION
It makes it possible to access the `vnodes` tree from `oncreate` hooks (currently it is only possible from `onupdate` ones.