### PR TITLE
Pass namespace to new children when updating their parent

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -176,7 +176,7 @@ module.exports = function($window) {
 					}
 					if (end < start) break
 				}
-				createNodes(parent, vnodes, start, end + 1, hooks, nextSibling, undefined)
+				createNodes(parent, vnodes, start, end + 1, hooks, nextSibling, ns)
 				removeNodes(parent, old, oldStart, oldEnd + 1, vnodes)
 			}
 		}


### PR DESCRIPTION
Hello,

First, sorry for my poor english :-/

When updating the children of an `svg` element with its own namespace (e.g. adding new `rect`), its children have to be created by using `document.createElementNS` instead of `document.createElement` in order to specify their namespace.

Gaspar.