### PR TITLE
Gotchas imply onbeforeupdate is inherently evil

### DIFF
--- a/docs/lifecycle-methods.md
+++ b/docs/lifecycle-methods.md
@@ -252,7 +252,7 @@ var WorkingComponent = {
 
 #### Avoid premature optimizations
 
-The `onbeforeupdate` hook should only be used as a last resort. Avoid using it unless you have a noticeable performance issue.
+You should only use `onbeforeupdate` to skip diffing as a last resort. Avoid using it unless you have a noticeable performance issue.
 
 Typically performance problems that can be fixed via `onbeforeupdate` boil down to one large array of items. In this context, typically "large" means any array that contains a large number of nodes, be it in a wide spread (the infamous 5000 row table), or in a deep, dense tree.
 


### PR DESCRIPTION
The premature optimisation warning talks about `onbeforeupdate` as though returning false were its only purpose. In fact it's also useful for transforming simple input into a detailed model for the view, input-state comparisons for change highlighting, etc.