### PR TITLE
Use Date.now() if available

### DIFF
--- a/api/throttle.js
+++ b/api/throttle.js
@@ -1,12 +1,16 @@
 "use strict"
 
+var ts = Date.now || function() {
+	return new Date().getTime()
+}
+
 module.exports = function(callback) {
 	//60fps translates to 16.6ms, round it down since setTimeout requires int
 	var time = 16
 	var last = 0, pending = null
 	var timeout = typeof requestAnimationFrame === "function" ? requestAnimationFrame : setTimeout
 	return function(synchronous) {
-		var now = new Date().getTime()
+		var now = ts()
 		if (synchronous === true || last === 0 || now - last >= time) {
 			last = now
 			callback()
@@ -15,7 +19,7 @@ module.exports = function(callback) {
 			pending = timeout(function() {
 				pending = null
 				callback()
-				last = new Date().getTime()
+				last = ts()
 			}, time - (now - last))
 		}
 	}


### PR DESCRIPTION
`Date.now()` appears to be faster in every browser I have locally, was running benchmarks using [this bin](https://jsbin.com/tirelul/1/edit?js,console,output).

Browser | `Date.now()` | `new Date().getTime()`
------------ | ------------- | -------------
Chrome Stable | 7,739,075 ops/sec ±4.11% (56 runs sampled) | 4,618,586 ops/sec ±2.47% (62 runs sampled)
Edge | 11,053,165 ops/sec ±0.47% (64 runs sampled) | 6,705,249 ops/sec ±1.98% (58 runs sampled)
Firefox Dev Edition | 22,770,971 ops/sec ±2.41% (62 runs sampled) | 5,356,074 ops/sec ±1.39% (60 runs sampled)
IE 11 | 4,767,852 ops/sec ±0.71% (60 runs sampled) | 3,619,536 ops/sec ±1.13% (57 runs sampled)

I also compared some timings for the throttled function in dbmonster at 50% in chrome stable. I wrapped the main throttle function in `console.time()`/`console.timeEnd()`, took about ~500 samples, and then looked at the median value for each.

Method | Median
--------- | -----------
`Date.now()` | 5.9291ms
`new Date().getTime()` | 5.9555ms

It's a small difference, but it seemed like a simple thing to test for/polyfill. Up to @lhorie if he thinks it's worth it.