### PR TITLE
Add failing test case for stream

### DIFF
--- a/util/tests/test-stream.js
+++ b/util/tests/test-stream.js
@@ -549,9 +549,17 @@ o.spec("stream", function() {
 			var absorbed = Stream.stream()
 			var mapped = stream.run(function(value) {return absorbed})
 
-			absorbed(2)
+			var depCallCount = 0
+			mapped.map(function (value) {
+				o(value).equals(200)
+				depCallCount += 1
+			})
+			o(depCallCount).equals(0)
 
-			o(mapped()).equals(2)
+			absorbed(200)
+			o(depCallCount).equals(1)
+
+			o(mapped()).equals(200)
 		})
 		o("works when updating pending stream to errored state", function() {
 			var stream = Stream.stream(undefined)


### PR DESCRIPTION
Here is a failing test of a problem I ran into today. The actual use case was trying to merge two `m.request`s together like so:

```js
m.request({ method: 'GET', url: 'http://example.com/user/10' })
  .run(function (user) {
    return m.request({ method: 'GET', url: `http://example.com/user/10/comments` })
        .map( comments => Object.assign(user, { comments: comments }) )
  })
  .map(function (result) {
    console.log("Result:", result)
  })
```

I assumed this would behave like JavaScript's Promise absorption. Am I incorrect in my assumption? The problem (if it is a problem) is demonstrated by the failing test.