### PR TITLE
`is` should be passed as `{is: is}`

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -70,8 +70,8 @@ module.exports = function($window) {
 		var is = attrs && attrs.is
 
 		var element = ns ?
-			is ? $doc.createElementNS(ns, tag, is) : $doc.createElementNS(ns, tag) :
-			is ? $doc.createElement(tag, is) : $doc.createElement(tag)
+			is ? $doc.createElementNS(ns, tag, {is: is}) : $doc.createElementNS(ns, tag) :
+			is ? $doc.createElement(tag, {is: is}) : $doc.createElement(tag)
 		vnode.dom = element
 
 		if (attrs != null) {


### PR DESCRIPTION
According to the [WhatWG DOM spec](https://dom.spec.whatwg.org/#dom-document-createelement), `createElement` and `createElementNS` dont take `is`, but an `option` object as a last, optional parameter. Its `is` property is used for the custom element lookup.

Caveat: I did not test this in any way nor do I have any experience with custom elements. I just noticed the discrepancy.