### PR TITLE
Move travis-scripts to be build-server only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ cache:
   directories:
   - node_modules
 
+# Custom install step so the travis scripts don't need to be in package.json
+install:
+  - npm install
+  - npm install @alrra/travis-scripts@^3.0.1
+
+# After a successful build create bundles & commit back to the repo
 after_success:
   - |
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,11 @@ install:
 after_success:
   - |
     
-    # Only want to do this on commits to $BRANCH
-    [ "$TRAVIS_PULL_REQUEST" == "true" -o "$TRAVIS_BRANCH" != "$BRANCH" ] && (echo Artifacts only built on $BRANCH; exit 0)
+    # Only want to commit things on commits to $BRANCH
+    if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] || [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
+      echo "Artifacts only built on $BRANCH"
+      exit 0
+    fi
       
     # Set up SSH environment
     $(npm bin)/set-up-ssh --key "$encrypted_8b86e0359d64_key" \

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 		"cover": "istanbul cover --print both ospec/bin/ospec"
 	},
 	"devDependencies": {
-		"@alrra/travis-scripts": "^3.0.1",
 		"eslint": "^2.10.2",
 		"istanbul": "^0.4.3"
 	},


### PR DESCRIPTION
No reason everyone who wants to do local dev should need to install `travis-scripts`, only the build server ever cares about them.