### PR TITLE
Migration docs: m.mount and m.route now require components where vdom nodes were once tolerated

### DIFF
--- a/docs/v1.x-migration.md
+++ b/docs/v1.x-migration.md
@@ -7,6 +7,7 @@
 - [Component `controller` function](#component-controller-function)
 - [Component arguments](#component-arguments)
 - [Passing components to `m()`](#passing-components-to-m)
+- [Passing vnodes to `m.mount()` and `m.route()`](#passing-vnodes-to-mmount-and-mroute)
 - [`m.route` mode](#mroute-mode)
 - [`m.route` and anchor tags](#mroute-and-anchor-tags)
 - [Reading/writing the current route](#readingwriting-the-current-route)
@@ -176,6 +177,34 @@ m("div", component);
 
 ```javascript
 m("div", m(component));
+```
+
+## Passing vnodes to `m.mount()` and `m.route()`
+
+In `v0.2.x`, `m.mount(element, component)` tolerated [vnodes](vnodes.md) as second arguments instead of [components](components.md) (even though it wasn't documented). Likewise, `m.route(element, defaultRoute, routes)` accepted vnodes as values in the `routes` object.
+
+In `v1.x`, components are required instead in both cases.
+
+### `v0.2.x`
+
+```javascript
+m.mount(element, m('i', 'hello'));
+m.mount(element, m(Component, attrs));
+
+m.route(element, '/', {
+    '/': m('b', 'bye')
+})
+```
+
+### `v1.x`
+
+```javascript
+m.mount(element, {view: function () {return m('i', 'hello')}});
+m.mount(element, {view: function () {return m(Component, attrs)}});
+
+m.route(element, '/', {
+    '/': {view: function () {return m('b', 'bye')}}
+})
 ```
 
 ## `m.route` mode


### PR DESCRIPTION
@tivac: split from #1172 ss discussed in the gitter chat