### PR TITLE
Set element style using cssText

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -441,11 +441,11 @@ module.exports = function($window) {
 
 	//style
 	function updateStyle(element, old, style) {
-		if (old === style) element.style = "", old = null
-		if (style == null) element.style = ""
-		else if (typeof style === "string") element.style = style
+		if (old === style) element.cssText = "", old = null
+		if (style == null) element.cssText = ""
+		else if (typeof style === "string") element.cssText = style
 		else {
-			if (typeof old === "string") element.style = ""
+			if (typeof old === "string") element.cssText = ""
 			for (var key in style) {
 				element.style[key] = style[key]
 			}


### PR DESCRIPTION
I can't for the life of me reduce this to a simple example, but here is the code in question from one of my projects: http://jsbin.com/kupoyubeta/1/edit?js,output . Unfortunately it works there, but this is what I'm seeing in my project:

1. Click a button, div animates in.
2. Later, a redraw occurs, and I get this error:

    Uncaught TypeError: Cannot set property style of #<HTMLElement> which has only a getter

Upon further investigation, I discovered the `element.style = ""` line was, for some reason, the culprit. Changing it to use cssText fixed it, and is apparently the official way to do it. https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-cssText