### PR TITLE
render clears non-mithril dom nodes

### DIFF
--- a/api/mount.js
+++ b/api/mount.js
@@ -1,7 +1,6 @@
 "use strict"
 
 var Vnode = require("../render/vnode")
-var coreRenderer = require("../render/render")
 var autoredraw = require("../api/autoredraw")
 var dummy = {view: function() {}}
 

--- a/render/render.js
+++ b/render/render.js
@@ -514,7 +514,12 @@ module.exports = function($window) {
 	function render(dom, vnodes) {
 		var hooks = []
 		var active = $doc.activeElement
-		if (dom.vnodes == null) dom.vnodes = []
+		
+		// First time rendering into a node clears it out
+		if (dom.vnodes == null) {
+			dom.vnodes = []
+			dom.textContent = "";
+		}
 
 		if (!(vnodes instanceof Array)) vnodes = [vnodes]
 		updateNodes(dom, dom.vnodes, Vnode.normalizeChildren(vnodes), hooks, null, undefined)

--- a/render/tests/index.html
+++ b/render/tests/index.html
@@ -38,6 +38,7 @@
 		<script src="test-input.js"></script>
 		<script src="test-textContent.js"></script>
 		<script src="test-component.js"></script>
+		<script src="test-render.js"></script>
 
 		<script>require("../../ospec/ospec").run()</script>
 	</body>

--- a/render/tests/test-render.js
+++ b/render/tests/test-render.js
@@ -1,0 +1,24 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var domMock = require("../../test-utils/domMock")
+var vdom = require("../../render/render")
+
+o.spec("render", function() {
+	var $window, root, render
+	o.beforeEach(function() {
+		$window = domMock()
+		root = $window.document.createElement("div")
+		render = vdom($window).render
+	})
+
+	o("overwrites existing content", function() {
+		var vnodes = [{tag: "a", text: null}]
+
+		root.appendChild($window.document.createElement("div"));
+
+		render(root, vnodes)
+
+		o(root.childNodes.length).equals(1)
+	})
+})


### PR DESCRIPTION
https://gitter.im/lhorie/mithril.js?at=57a4e8c7978997001e99ae35

> **tivac** Huh
> **tivac** when you `m.mount` into an element w/ the rewrite it doesn't overwrite existing content
> **tivac** `rewrite` - https://jsbin.com/titama/edit?html,js,output
> **tivac** `0.2.5` - https://jsbin.com/kopakex/1/edit?html,js,output

https://gitter.im/lhorie/mithril.js?at=57a4ea65d097eb6b2cc89f6c

> **tivac** @mindeavor @lhorie [docs for `m.mount`](https://github.com/lhorie/mithril.js/blob/rewrite/docs/mount.md) don't seem to clearly state one way or another if it should blow up existing non-mithril DOM elements.
> **tivac** So I wonder if this is intended behavior or not
> **tivac** TO THE TESTS
> **tivac** No tests for or against this behavior

https://gitter.im/lhorie/mithril.js?at=57a4ebc9fb162b752ca18d5f
> **lhorie** it probably should mirror 0.2

And with this PR, now it does mirror `0.2.x`. I wasn't totally sure where the test should live so I added it to a new generic `test-render.js` file, do let me know if you'd prefer it elsewhere.

(the line removed in `api/mount.js` is just an ESLint warning that I happened to see)