### PR TITLE
Skip diff for cached, non-keyed nodes fix #1206

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -109,7 +109,7 @@ module.exports = function($window) {
 
 	//update
 	function updateNodes(parent, old, vnodes, hooks, nextSibling, ns) {
-		if (old == null && vnodes == null) return
+		if (old === vnodes || old == null && vnodes == null) return
 		else if (old == null) createNodes(parent, vnodes, 0, vnodes.length, hooks, nextSibling, undefined)
 		else if (vnodes == null) removeNodes(parent, old, 0, old.length, vnodes)
 		else {
@@ -118,7 +118,7 @@ module.exports = function($window) {
 			
 			if (old.length === vnodes.length && vnodes[0] != null && vnodes[0].key == null) {
 				for (var i = 0; i < old.length; i++) {
-					if (old[i] == null && vnodes[i] == null) continue
+					if (old[i] === vnodes[i] || old[i] == null && vnodes[i] == null) continue
 					else if (old[i] == null) insertNode(parent, createNode(vnodes[i], hooks, ns), getNextSibling(old, i + 1, nextSibling))
 					else if (vnodes[i] == null) removeNodes(parent, old, i, i + 1, vnodes)
 					else updateNode(parent, old[i], vnodes[i], hooks, getNextSibling(old, i + 1, nextSibling), recycling, ns)

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -845,4 +845,22 @@ o.spec("updateNodes", function() {
 		o(root.childNodes[0].nodeName).equals("A")
 		o(root.childNodes[1].nodeName).equals("S")
 	})
+	o("cached, non-keyed nodes skip diff", function () {
+		var onupdate = o.spy();
+		var cached = {tag:"a", attrs:{onupdate: onupdate}}
+
+		render(root, cached)
+		render(root, cached)
+
+		o(onupdate.callCount).equals(0)
+	})
+	o("cached, keyed nodes skip diff", function () {
+		var onupdate = o.spy();
+		var cached = {tag:"a", key:"a", attrs:{onupdate: onupdate}}
+
+		render(root, cached)
+		render(root, cached)
+
+		o(onupdate.callCount).equals(0)
+	})
 })


### PR DESCRIPTION
... and obsoletes #1220.

I use explicit tests, but using one loose equality test (`if (old == vnodes){}`, likewise for individual nodes) may also work and would do the same behind the scenes. I'm not equipped for benchmarking Mithril right now, though, so I'll leave it to you.