### PR TITLE
Update style using element.style.cssText instead of element.cssText

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -441,11 +441,11 @@ module.exports = function($window) {
 
 	//style
 	function updateStyle(element, old, style) {
-		if (old === style) element.cssText = "", old = null
-		if (style == null) element.cssText = ""
-		else if (typeof style === "string") element.cssText = style
+		if (old === style) element.style.cssText = "", old = null
+		if (style == null) element.style.cssText = ""
+		else if (typeof style === "string") element.style.cssText = style
 		else {
-			if (typeof old === "string") element.cssText = ""
+			if (typeof old === "string") element.style.cssText = ""
 			for (var key in style) {
 				element.style[key] = style[key]
 			}


### PR DESCRIPTION
Hello,

I think that `updateStyle` has to use `element.style.cssText` instead of `element.cssText` to replace the CSS style of an element.

Gaspar.