### PR TITLE
Set dependencies when no window for isomorphic compatibility

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -4,6 +4,15 @@
 	"use strict"
 	/* eslint-disable no-undef */
 	var m = factory(global)
+	/*	Set dependencies when no window for isomorphic compatibility */
+	if(typeof window === "undefined") {
+		m.deps({
+			document: typeof document !== "undefined"? document: {},
+			location: typeof location !== "undefined"? location: {},
+			clearTimeout: clearTimeout,
+			setTimeout: setTimeout
+		});
+	}
 	if (typeof module === "object" && module != null && module.exports) {
 		module.exports = m
 	} else if (typeof define === "function" && define.amd) {


### PR DESCRIPTION
Ran into an issue with isomorphism - if I change a model on the server, it may in some circumstances try to re-render, and throw an error:

TypeError: $requestAnimationFrame is not a function

To circumvent this, we check for the availability of 'window', and set mocked dependencies instead.