### PR TITLE
Temporary fix for broken bundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 "use strict"
 
 var log = console.error.bind(console)
-var Stream = require("./util/stream")(log)
+var StreamFactory = require("./util/stream")
+var Stream = StreamFactory(log)
 var m = require("./render/hyperscript")
 var renderService = require("./render/render")(window)
 var requestService = require("./request/request")(window, log)


### PR DESCRIPTION
The current bundles were throwing "Stream is not a function".
The proper place to fix this would probably be in the bundler, but for now this circumvents the issue.
It appears the instantiated "Stream" will be cached and used inside the requestService that also requires './util/stream',  instead of just what's inside './util/stream'.