### PR TITLE
Piecemeal stream usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 "use strict"
 
 var log = console.error.bind(console)
-var StreamFactory = require("./util/stream")
-var Stream = StreamFactory(log)
+var stream = require("./stream");
 var m = require("./render/hyperscript")
 var renderService = require("./render/render")(window)
 var requestService = require("./request/request")(window, log)
@@ -14,11 +13,7 @@ m.route = require("./api/router")(window, renderService, redrawService)
 m.mount = require("./api/mount")(renderService, redrawService)
 m.trust = require("./render/trust")
 m.withAttr = require("./util/withAttr")
-m.prop = Stream.stream
-m.prop.combine = Stream.combine
-m.prop.reject = Stream.reject
-m.prop.merge = Stream.merge
-m.prop.HALT = Stream.HALT
+m.prop = stream
 m.render = renderService.render
 m.redraw = redrawService.publish
 m.request = requestService.xhr

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict"
 
 var log = console.error.bind(console)
-var stream = require("./stream/index");
+var stream = require("./stream/index")
 var m = require("./render/hyperscript")
 var renderService = require("./render/render")(window)
 var requestService = require("./request/request")(window, log)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict"
 
 var log = console.error.bind(console)
-var stream = require("./stream");
+var stream = require("./stream/index");
 var m = require("./render/hyperscript")
 var renderService = require("./render/render")(window)
 var requestService = require("./request/request")(window, log)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict"
 
 var log = console.error.bind(console)
-var s = require("./stream/index")
+var defaultStream = require("./stream/index")
 var m = require("./render/hyperscript")
 var renderService = require("./render/render")(window)
 var requestService = require("./request/request")(window, log)
@@ -13,7 +13,7 @@ m.route = require("./api/router")(window, renderService, redrawService)
 m.mount = require("./api/mount")(renderService, redrawService)
 m.trust = require("./render/trust")
 m.withAttr = require("./util/withAttr")
-m.prop = s
+m.prop = defaultStream
 m.render = renderService.render
 m.redraw = redrawService.publish
 m.request = requestService.xhr

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict"
 
 var log = console.error.bind(console)
-var stream = require("./stream/index")
+var s = require("./stream/index")
 var m = require("./render/hyperscript")
 var renderService = require("./render/render")(window)
 var requestService = require("./request/request")(window, log)
@@ -13,7 +13,7 @@ m.route = require("./api/router")(window, renderService, redrawService)
 m.mount = require("./api/mount")(renderService, redrawService)
 m.trust = require("./render/trust")
 m.withAttr = require("./util/withAttr")
-m.prop = stream
+m.prop = s
 m.render = renderService.render
 m.redraw = redrawService.publish
 m.request = requestService.xhr

--- a/mithril.js
+++ b/mithril.js
@@ -5,81 +5,81 @@ var log = console.error.bind(console)
 var StreamFactory = function(log) {
 	var guid = 0, noop = function() {}, HALT = {}
 	function createStream() {
-		function stream1() {
-			if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream1, arguments[0], undefined)
-			return stream1._state.value
+		function stream() {
+			if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream, arguments[0], undefined)
+			return stream._state.value
 		}
-		initStream(stream1, arguments)
-		if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream1, arguments[0], undefined)
-		return stream1
+		initStream(stream, arguments)
+		if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream, arguments[0], undefined)
+		return stream
 	}
-	function initStream(stream1, args) {
-		stream1.constructor = createStream
-		stream1._state = {id: guid++, value: undefined, error: undefined, state: 0, derive: undefined, recover: undefined, deps: {}, parents: [], errorStream: undefined, endStream: undefined}
-		stream1.map = map, stream1.ap = ap, stream1.of = createStream
-		stream1.valueOf = valueOf, stream1.toJSON = toJSON, stream1.toString = valueOf
-		stream1.run = run, stream1.catch = doCatch
-		Object.defineProperties(stream1, {
+	function initStream(stream, args) {
+		stream.constructor = createStream
+		stream._state = {id: guid++, value: undefined, error: undefined, state: 0, derive: undefined, recover: undefined, deps: {}, parents: [], errorStream: undefined, endStream: undefined}
+		stream.map = map, stream.ap = ap, stream.of = createStream
+		stream.valueOf = valueOf, stream.toJSON = toJSON, stream.toString = valueOf
+		stream.run = run, stream.catch = doCatch
+		Object.defineProperties(stream, {
 			error: {get: function() {
-				if (!stream1._state.errorStream) {
+				if (!stream._state.errorStream) {
 					var errorStream = function() {
-						if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream1, undefined, arguments[0])
-						return stream1._state.error
+						if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream, undefined, arguments[0])
+						return stream._state.error
 					}
 					initStream(errorStream, [])
-					initDependency(errorStream, [stream1], noop, noop)
-					stream1._state.errorStream = errorStream
+					initDependency(errorStream, [stream], noop, noop)
+					stream._state.errorStream = errorStream
 				}
-				return stream1._state.errorStream
+				return stream._state.errorStream
 			}},
 			end: {get: function() {
-				if (!stream1._state.endStream) {
+				if (!stream._state.endStream) {
 					var endStream = createStream()
 					endStream.map(function(value) {
-						if (value === true) unregisterStream(stream1), unregisterStream(endStream)
+						if (value === true) unregisterStream(stream), unregisterStream(endStream)
 						return value
 					})
-					stream1._state.endStream = endStream
+					stream._state.endStream = endStream
 				}
-				return stream1._state.endStream
+				return stream._state.endStream
 			}}
 		})
 	}
-	function updateStream(stream1, value, error) {
-		updateState(stream1, value, error)
-		for (var id in stream1._state.deps) updateDependency(stream1._state.deps[id], false)
-		finalize(stream1)
+	function updateStream(stream, value, error) {
+		updateState(stream, value, error)
+		for (var id in stream._state.deps) updateDependency(stream._state.deps[id], false)
+		finalize(stream)
 	}
-	function updateState(stream1, value, error) {
+	function updateState(stream, value, error) {
 		error = unwrapError(value, error)
-		if (error !== undefined && typeof stream1._state.recover === "function") {
-			if (!resolve(stream1, updateValues, true)) return
+		if (error !== undefined && typeof stream._state.recover === "function") {
+			if (!resolve(stream, updateValues, true)) return
 		}
-		else updateValues(stream1, value, error)
-		stream1._state.changed = true
-		if (stream1._state.state !== 2) stream1._state.state = 1
+		else updateValues(stream, value, error)
+		stream._state.changed = true
+		if (stream._state.state !== 2) stream._state.state = 1
 	}
-	function updateValues(stream1, value, error) {
-		stream1._state.value = value
-		stream1._state.error = error
+	function updateValues(stream, value, error) {
+		stream._state.value = value
+		stream._state.error = error
 	}
-	function updateDependency(stream1, mustSync) {
-		var state = stream1._state, parents = state.parents
+	function updateDependency(stream, mustSync) {
+		var state = stream._state, parents = state.parents
 		if (parents.length > 0 && parents.filter(active).length === parents.length && (mustSync || parents.filter(changed).length > 0)) {
 			var failed = parents.filter(errored)
-			if (failed.length > 0) updateState(stream1, undefined, failed[0]._state.error)
-			else resolve(stream1, updateState, false)
+			if (failed.length > 0) updateState(stream, undefined, failed[0]._state.error)
+			else resolve(stream, updateState, false)
 		}
 	}
-	function resolve(stream1, update, shouldRecover) {
+	function resolve(stream, update, shouldRecover) {
 		try {
-			var value = shouldRecover ? stream1._state.recover() : stream1._state.derive()
+			var value = shouldRecover ? stream._state.recover() : stream._state.derive()
 			if (value === HALT) return false
-			update(stream1, value, undefined)
+			update(stream, value, undefined)
 		}
 		catch (e) {
-			update(stream1, undefined, e.__error != null ? e.__error : e)
-			if (e.__error == null) reportUncaughtError(stream1, e)
+			update(stream, undefined, e.__error != null ? e.__error : e)
+			if (e.__error == null) reportUncaughtError(stream, e)
 		}
 		return true
 	}
@@ -90,28 +90,28 @@ var StreamFactory = function(log) {
 		}
 		return error
 	}
-	function finalize(stream1) {
-		stream1._state.changed = false
-		for (var id in stream1._state.deps) stream1._state.deps[id]._state.changed = false
+	function finalize(stream) {
+		stream._state.changed = false
+		for (var id in stream._state.deps) stream._state.deps[id]._state.changed = false
 	}
-	function reportUncaughtError(stream1, e) {
-		if (Object.keys(stream1._state.deps).length === 0) {
+	function reportUncaughtError(stream, e) {
+		if (Object.keys(stream._state.deps).length === 0) {
 			setTimeout(function() {
-				if (Object.keys(stream1._state.deps).length === 0) log(e)
+				if (Object.keys(stream._state.deps).length === 0) log(e)
 			}, 0)
 		}
 	}
 	function run(fn) {
-		var self = createStream(), stream1 = this
-		return initDependency(self, [stream1], function() {
-			return absorb(self, fn(stream1()))
+		var self = createStream(), stream = this
+		return initDependency(self, [stream], function() {
+			return absorb(self, fn(stream()))
 		}, undefined)
 	}
 	function doCatch(fn) {
-		var self = createStream(), stream1 = this
-		var derive = function() {return stream1._state.value}
-		var recover = function() {return absorb(self, fn(stream1._state.error))}
-		return initDependency(self, [stream1], derive, recover)
+		var self = createStream(), stream = this
+		var derive = function() {return stream._state.value}
+		var recover = function() {return absorb(self, fn(stream._state.error))}
+		return initDependency(self, [stream], derive, recover)
 	}
 	function combine(fn, streams) {
 		return initDependency(createStream(), streams, function() {
@@ -120,12 +120,12 @@ var StreamFactory = function(log) {
 			return fn.apply(this, streams.concat([streams.filter(changed)]))
 		}, undefined)
 	}
-	function absorb(stream1, value) {
+	function absorb(stream, value) {
 		if (value != null && value.constructor === createStream) {
 			var absorbable = value
 			var update = function() {
-				updateState(stream1, absorbable._state.value, absorbable._state.error)
-				for (var id in stream1._state.deps) updateDependency(stream1._state.deps[id], false)
+				updateState(stream, absorbable._state.value, absorbable._state.error)
+				for (var id in stream._state.deps) updateDependency(stream._state.deps[id], false)
 			}
 			absorbable.map(update).catch(function(e) {
 				update()
@@ -147,52 +147,51 @@ var StreamFactory = function(log) {
 		updateDependency(dep, true)
 		return dep
 	}
-	function registerDependency(stream1, parents) {
+	function registerDependency(stream, parents) {
 		for (var i = 0; i < parents.length; i++) {
-			parents[i]._state.deps[stream1._state.id] = stream1
-			registerDependency(stream1, parents[i]._state.parents)
+			parents[i]._state.deps[stream._state.id] = stream
+			registerDependency(stream, parents[i]._state.parents)
 		}
 	}
-	function unregisterStream(stream1) {
-		for (var i = 0; i < stream1._state.parents.length; i++) {
-			var parent = stream1._state.parents[i]
-			delete parent._state.deps[stream1._state.id]
+	function unregisterStream(stream) {
+		for (var i = 0; i < stream._state.parents.length; i++) {
+			var parent = stream._state.parents[i]
+			delete parent._state.deps[stream._state.id]
 		}
-		for (var id in stream1._state.deps) {
-			var dependent = stream1._state.deps[id]
-			var index = dependent._state.parents.indexOf(stream1)
+		for (var id in stream._state.deps) {
+			var dependent = stream._state.deps[id]
+			var index = dependent._state.parents.indexOf(stream)
 			if (index > -1) dependent._state.parents.splice(index, 1)
 		}
-		stream1._state.state = 2 //ended
-		stream1._state.deps = {}
+		stream._state.state = 2 //ended
+		stream._state.deps = {}
 	}
-	function map(fn) {return combine(function(stream1) {return fn(stream1())}, [this])}
-	function ap(stream1) {return combine(function(s1, s2) {return s1()(s2())}, [this, stream1])}
+	function map(fn) {return combine(function(stream) {return fn(stream())}, [this])}
+	function ap(stream) {return combine(function(s1, s2) {return s1()(s2())}, [this, stream])}
 	function valueOf() {return this._state.value}
 	function toJSON() {return this._state.value != null && typeof this._state.value.toJSON === "function" ? this._state.value.toJSON() : this._state.value}
-	function active(stream1) {return stream1._state.state === 1}
-	function changed(stream1) {return stream1._state.changed}
-	function notEnded(stream1) {return stream1._state.state !== 2}
-	function errored(stream1) {return stream1._state.error}
+	function active(stream) {return stream._state.state === 1}
+	function changed(stream) {return stream._state.changed}
+	function notEnded(stream) {return stream._state.state !== 2}
+	function errored(stream) {return stream._state.error}
 	function reject(e) {
-		var stream1 = createStream()
-		stream1.error(e)
-		return stream1
+		var stream = createStream()
+		stream.error(e)
+		return stream
 	}
 	function merge(streams) {
 		return combine(function () {
-			return streams.map(function(s) {return s()})
+			return streams.map(function(s1) {return s1()})
 		}, streams)
 	}
-	return {stream1: createStream, merge: merge, combine: combine, reject: reject, HALT: HALT}
+	return {stream: createStream, merge: merge, combine: combine, reject: reject, HALT: HALT}
 }
 var Stream = StreamFactory(log)
-var stream = Stream.stream
-stream.combine = Stream.combine
-stream.reject = Stream.reject
-stream.merge = Stream.merge
-stream.HALT = Stream.HALT
-;
+var s = Stream.stream
+s.combine = Stream.combine
+s.reject = Stream.reject
+s.merge = Stream.merge
+s.HALT = Stream.HALT
 function Vnode(tag, key, attrs, children, text, dom) {
 	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: {}, events: undefined, instance: undefined}
 }
@@ -207,7 +206,7 @@ Vnode.normalizeChildren = function normalizeChildren(children) {
 	}
 	return children
 }
-var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
+var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s2*=\s2*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
 var selectorCache = {}
 function hyperscript(selector) {
 	if (selector == null || typeof selector !== "string" && selector.view == null) {
@@ -297,7 +296,7 @@ var renderService = function($window) {
 		return vnode.dom = $doc.createTextNode(vnode.children)
 	}
 	function createHTML(vnode) {
-		var match = vnode.children.match(/^\s*?<(\w+)/im) || []
+		var match = vnode.children.match(/^\s3*?<(\w+)/im) || []
 		var parent = {caption: "table", thead: "table", tbody: "table", tfoot: "table", tr: "tbody", th: "tr", td: "tr", colgroup: "table", col: "colgroup"}[match[1]] || "div"
 		var temp = $doc.createElement(parent)
 		temp.innerHTML = vnode.children
@@ -793,8 +792,8 @@ var requestService = function($window, log) {
 	function setCompletionCallback(callback) {oncompletion = callback}
 	
 	function xhr(args) {
-		var stream2 = Stream.stream()
-		if (args.initialValue !== undefined) stream2(args.initialValue)
+		var stream = Stream.stream()
+		if (args.initialValue !== undefined) stream(args.initialValue)
 		
 		var useBody = typeof args.useBody === "boolean" ? args.useBody : args.method !== "GET" && args.method !== "TRACE"
 		
@@ -823,16 +822,16 @@ var requestService = function($window, log) {
 				try {
 					var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
 					if (xhr.status >= 200 && xhr.status < 300) {
-						stream2(cast(args.type, response))
+						stream(cast(args.type, response))
 					}
 					else {
 						var error = new Error(xhr.responseText)
 						for (var key in response) error[key] = response[key]
-						stream2.error(error)
+						stream.error(error)
 					}
 				}
 				catch (e) {
-					stream2.error(e)
+					stream.error(e)
 				}
 				if (typeof oncompletion === "function") oncompletion()
 			}
@@ -841,23 +840,23 @@ var requestService = function($window, log) {
 		if (useBody) xhr.send(args.data)
 		else xhr.send()
 		
-		return stream2
+		return stream
 	}
 	function jsonp(args) {
-		var stream2 = Stream.stream()
-		if (args.initialValue !== undefined) stream2(args.initialValue)
+		var stream = Stream.stream()
+		if (args.initialValue !== undefined) stream(args.initialValue)
 		
 		var callbackName = args.callbackName || "_mithril_" + Math.round(Math.random() * 1e16) + "_" + callbackCount++
 		var script = $window.document.createElement("script")
 		$window[callbackName] = function(data) {
 			script.parentNode.removeChild(script)
-			stream2(cast(args.type, data))
+			stream(cast(args.type, data))
 			if (typeof oncompletion === "function") oncompletion()
 			delete $window[callbackName]
 		}
 		script.onerror = function() {
 			script.parentNode.removeChild(script)
-			stream2.error(new Error("JSONP request failed"))
+			stream.error(new Error("JSONP request failed"))
 			if (typeof oncompletion === "function") oncompletion()
 			delete $window[callbackName]
 		}
@@ -866,7 +865,7 @@ var requestService = function($window, log) {
 		args.data[args.callbackKey || "callback"] = callbackName
 		script.src = assemble(args.url, args.data)
 		$window.document.documentElement.appendChild(script)
-		return stream2
+		return stream
 	}
 	function interpolate(url, data) {
 		if (data == null) return url
@@ -1141,7 +1140,7 @@ m.withAttr = function(attrName, callback, context) {
 		return callback.call(context || this, attrName in e.currentTarget ? e.currentTarget[attrName] : e.currentTarget.getAttribute(attrName))
 	}
 }
-m.prop = stream
+m.prop = s
 m.render = renderService.render
 m.redraw = redrawService.publish
 m.request = requestService.xhr

--- a/mithril.js
+++ b/mithril.js
@@ -181,17 +181,17 @@ var StreamFactory = function(log) {
 	}
 	function merge(streams) {
 		return combine(function () {
-			return streams.map(function(s1) {return s1()})
+			return streams.map(function(s) {return s()})
 		}, streams)
 	}
 	return {stream: createStream, merge: merge, combine: combine, reject: reject, HALT: HALT}
 }
 var Stream = StreamFactory(log)
-var s = Stream.stream
-s.combine = Stream.combine
-s.reject = Stream.reject
-s.merge = Stream.merge
-s.HALT = Stream.HALT
+var defaultStream = Stream.stream
+defaultStream.combine = Stream.combine
+defaultStream.reject = Stream.reject
+defaultStream.merge = Stream.merge
+defaultStream.HALT = Stream.HALT
 function Vnode(tag, key, attrs, children, text, dom) {
 	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: {}, events: undefined, instance: undefined}
 }
@@ -206,7 +206,7 @@ Vnode.normalizeChildren = function normalizeChildren(children) {
 	}
 	return children
 }
-var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s2*=\s2*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
+var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
 var selectorCache = {}
 function hyperscript(selector) {
 	if (selector == null || typeof selector !== "string" && selector.view == null) {
@@ -296,7 +296,7 @@ var renderService = function($window) {
 		return vnode.dom = $doc.createTextNode(vnode.children)
 	}
 	function createHTML(vnode) {
-		var match = vnode.children.match(/^\s3*?<(\w+)/im) || []
+		var match = vnode.children.match(/^\s*?<(\w+)/im) || []
 		var parent = {caption: "table", thead: "table", tbody: "table", tfoot: "table", tr: "tbody", th: "tr", td: "tr", colgroup: "table", col: "colgroup"}[match[1]] || "div"
 		var temp = $doc.createElement(parent)
 		temp.innerHTML = vnode.children
@@ -1140,7 +1140,7 @@ m.withAttr = function(attrName, callback, context) {
 		return callback.call(context || this, attrName in e.currentTarget ? e.currentTarget[attrName] : e.currentTarget.getAttribute(attrName))
 	}
 }
-m.prop = s
+m.prop = defaultStream
 m.render = renderService.render
 m.redraw = redrawService.publish
 m.request = requestService.xhr

--- a/mithril.js
+++ b/mithril.js
@@ -1,84 +1,85 @@
 new function() {
 
 var log = console.error.bind(console)
+var log = console.error.bind(console)
 var StreamFactory = function(log) {
 	var guid = 0, noop = function() {}, HALT = {}
 	function createStream() {
-		function stream() {
-			if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream, arguments[0], undefined)
-			return stream._state.value
+		function stream1() {
+			if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream1, arguments[0], undefined)
+			return stream1._state.value
 		}
-		initStream(stream, arguments)
-		if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream, arguments[0], undefined)
-		return stream
+		initStream(stream1, arguments)
+		if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream1, arguments[0], undefined)
+		return stream1
 	}
-	function initStream(stream, args) {
-		stream.constructor = createStream
-		stream._state = {id: guid++, value: undefined, error: undefined, state: 0, derive: undefined, recover: undefined, deps: {}, parents: [], errorStream: undefined, endStream: undefined}
-		stream.map = map, stream.ap = ap, stream.of = createStream
-		stream.valueOf = valueOf, stream.toJSON = toJSON, stream.toString = valueOf
-		stream.run = run, stream.catch = doCatch
-		Object.defineProperties(stream, {
+	function initStream(stream1, args) {
+		stream1.constructor = createStream
+		stream1._state = {id: guid++, value: undefined, error: undefined, state: 0, derive: undefined, recover: undefined, deps: {}, parents: [], errorStream: undefined, endStream: undefined}
+		stream1.map = map, stream1.ap = ap, stream1.of = createStream
+		stream1.valueOf = valueOf, stream1.toJSON = toJSON, stream1.toString = valueOf
+		stream1.run = run, stream1.catch = doCatch
+		Object.defineProperties(stream1, {
 			error: {get: function() {
-				if (!stream._state.errorStream) {
+				if (!stream1._state.errorStream) {
 					var errorStream = function() {
-						if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream, undefined, arguments[0])
-						return stream._state.error
+						if (arguments.length > 0 && arguments[0] !== HALT) updateStream(stream1, undefined, arguments[0])
+						return stream1._state.error
 					}
 					initStream(errorStream, [])
-					initDependency(errorStream, [stream], noop, noop)
-					stream._state.errorStream = errorStream
+					initDependency(errorStream, [stream1], noop, noop)
+					stream1._state.errorStream = errorStream
 				}
-				return stream._state.errorStream
+				return stream1._state.errorStream
 			}},
 			end: {get: function() {
-				if (!stream._state.endStream) {
+				if (!stream1._state.endStream) {
 					var endStream = createStream()
 					endStream.map(function(value) {
-						if (value === true) unregisterStream(stream), unregisterStream(endStream)
+						if (value === true) unregisterStream(stream1), unregisterStream(endStream)
 						return value
 					})
-					stream._state.endStream = endStream
+					stream1._state.endStream = endStream
 				}
-				return stream._state.endStream
+				return stream1._state.endStream
 			}}
 		})
 	}
-	function updateStream(stream, value, error) {
-		updateState(stream, value, error)
-		for (var id in stream._state.deps) updateDependency(stream._state.deps[id], false)
-		finalize(stream)
+	function updateStream(stream1, value, error) {
+		updateState(stream1, value, error)
+		for (var id in stream1._state.deps) updateDependency(stream1._state.deps[id], false)
+		finalize(stream1)
 	}
-	function updateState(stream, value, error) {
+	function updateState(stream1, value, error) {
 		error = unwrapError(value, error)
-		if (error !== undefined && typeof stream._state.recover === "function") {
-			if (!resolve(stream, updateValues, true)) return
+		if (error !== undefined && typeof stream1._state.recover === "function") {
+			if (!resolve(stream1, updateValues, true)) return
 		}
-		else updateValues(stream, value, error)
-		stream._state.changed = true
-		if (stream._state.state !== 2) stream._state.state = 1
+		else updateValues(stream1, value, error)
+		stream1._state.changed = true
+		if (stream1._state.state !== 2) stream1._state.state = 1
 	}
-	function updateValues(stream, value, error) {
-		stream._state.value = value
-		stream._state.error = error
+	function updateValues(stream1, value, error) {
+		stream1._state.value = value
+		stream1._state.error = error
 	}
-	function updateDependency(stream, mustSync) {
-		var state = stream._state, parents = state.parents
+	function updateDependency(stream1, mustSync) {
+		var state = stream1._state, parents = state.parents
 		if (parents.length > 0 && parents.filter(active).length === parents.length && (mustSync || parents.filter(changed).length > 0)) {
 			var failed = parents.filter(errored)
-			if (failed.length > 0) updateState(stream, undefined, failed[0]._state.error)
-			else resolve(stream, updateState, false)
+			if (failed.length > 0) updateState(stream1, undefined, failed[0]._state.error)
+			else resolve(stream1, updateState, false)
 		}
 	}
-	function resolve(stream, update, shouldRecover) {
+	function resolve(stream1, update, shouldRecover) {
 		try {
-			var value = shouldRecover ? stream._state.recover() : stream._state.derive()
+			var value = shouldRecover ? stream1._state.recover() : stream1._state.derive()
 			if (value === HALT) return false
-			update(stream, value, undefined)
+			update(stream1, value, undefined)
 		}
 		catch (e) {
-			update(stream, undefined, e.__error != null ? e.__error : e)
-			if (e.__error == null) reportUncaughtError(stream, e)
+			update(stream1, undefined, e.__error != null ? e.__error : e)
+			if (e.__error == null) reportUncaughtError(stream1, e)
 		}
 		return true
 	}
@@ -89,28 +90,28 @@ var StreamFactory = function(log) {
 		}
 		return error
 	}
-	function finalize(stream) {
-		stream._state.changed = false
-		for (var id in stream._state.deps) stream._state.deps[id]._state.changed = false
+	function finalize(stream1) {
+		stream1._state.changed = false
+		for (var id in stream1._state.deps) stream1._state.deps[id]._state.changed = false
 	}
-	function reportUncaughtError(stream, e) {
-		if (Object.keys(stream._state.deps).length === 0) {
+	function reportUncaughtError(stream1, e) {
+		if (Object.keys(stream1._state.deps).length === 0) {
 			setTimeout(function() {
-				if (Object.keys(stream._state.deps).length === 0) log(e)
+				if (Object.keys(stream1._state.deps).length === 0) log(e)
 			}, 0)
 		}
 	}
 	function run(fn) {
-		var self = createStream(), stream = this
-		return initDependency(self, [stream], function() {
-			return absorb(self, fn(stream()))
+		var self = createStream(), stream1 = this
+		return initDependency(self, [stream1], function() {
+			return absorb(self, fn(stream1()))
 		}, undefined)
 	}
 	function doCatch(fn) {
-		var self = createStream(), stream = this
-		var derive = function() {return stream._state.value}
-		var recover = function() {return absorb(self, fn(stream._state.error))}
-		return initDependency(self, [stream], derive, recover)
+		var self = createStream(), stream1 = this
+		var derive = function() {return stream1._state.value}
+		var recover = function() {return absorb(self, fn(stream1._state.error))}
+		return initDependency(self, [stream1], derive, recover)
 	}
 	function combine(fn, streams) {
 		return initDependency(createStream(), streams, function() {
@@ -119,12 +120,12 @@ var StreamFactory = function(log) {
 			return fn.apply(this, streams.concat([streams.filter(changed)]))
 		}, undefined)
 	}
-	function absorb(stream, value) {
+	function absorb(stream1, value) {
 		if (value != null && value.constructor === createStream) {
 			var absorbable = value
 			var update = function() {
-				updateState(stream, absorbable._state.value, absorbable._state.error)
-				for (var id in stream._state.deps) updateDependency(stream._state.deps[id], false)
+				updateState(stream1, absorbable._state.value, absorbable._state.error)
+				for (var id in stream1._state.deps) updateDependency(stream1._state.deps[id], false)
 			}
 			absorbable.map(update).catch(function(e) {
 				update()
@@ -146,46 +147,52 @@ var StreamFactory = function(log) {
 		updateDependency(dep, true)
 		return dep
 	}
-	function registerDependency(stream, parents) {
+	function registerDependency(stream1, parents) {
 		for (var i = 0; i < parents.length; i++) {
-			parents[i]._state.deps[stream._state.id] = stream
-			registerDependency(stream, parents[i]._state.parents)
+			parents[i]._state.deps[stream1._state.id] = stream1
+			registerDependency(stream1, parents[i]._state.parents)
 		}
 	}
-	function unregisterStream(stream) {
-		for (var i = 0; i < stream._state.parents.length; i++) {
-			var parent = stream._state.parents[i]
-			delete parent._state.deps[stream._state.id]
+	function unregisterStream(stream1) {
+		for (var i = 0; i < stream1._state.parents.length; i++) {
+			var parent = stream1._state.parents[i]
+			delete parent._state.deps[stream1._state.id]
 		}
-		for (var id in stream._state.deps) {
-			var dependent = stream._state.deps[id]
-			var index = dependent._state.parents.indexOf(stream)
+		for (var id in stream1._state.deps) {
+			var dependent = stream1._state.deps[id]
+			var index = dependent._state.parents.indexOf(stream1)
 			if (index > -1) dependent._state.parents.splice(index, 1)
 		}
-		stream._state.state = 2 //ended
-		stream._state.deps = {}
+		stream1._state.state = 2 //ended
+		stream1._state.deps = {}
 	}
-	function map(fn) {return combine(function(stream) {return fn(stream())}, [this])}
-	function ap(stream) {return combine(function(s1, s2) {return s1()(s2())}, [this, stream])}
+	function map(fn) {return combine(function(stream1) {return fn(stream1())}, [this])}
+	function ap(stream1) {return combine(function(s1, s2) {return s1()(s2())}, [this, stream1])}
 	function valueOf() {return this._state.value}
 	function toJSON() {return this._state.value != null && typeof this._state.value.toJSON === "function" ? this._state.value.toJSON() : this._state.value}
-	function active(stream) {return stream._state.state === 1}
-	function changed(stream) {return stream._state.changed}
-	function notEnded(stream) {return stream._state.state !== 2}
-	function errored(stream) {return stream._state.error}
+	function active(stream1) {return stream1._state.state === 1}
+	function changed(stream1) {return stream1._state.changed}
+	function notEnded(stream1) {return stream1._state.state !== 2}
+	function errored(stream1) {return stream1._state.error}
 	function reject(e) {
-		var stream = createStream()
-		stream.error(e)
-		return stream
+		var stream1 = createStream()
+		stream1.error(e)
+		return stream1
 	}
 	function merge(streams) {
 		return combine(function () {
 			return streams.map(function(s) {return s()})
 		}, streams)
 	}
-	return {stream: createStream, merge: merge, combine: combine, reject: reject, HALT: HALT}
+	return {stream1: createStream, merge: merge, combine: combine, reject: reject, HALT: HALT}
 }
 var Stream = StreamFactory(log)
+var stream = Stream.stream
+stream.combine = Stream.combine
+stream.reject = Stream.reject
+stream.merge = Stream.merge
+stream.HALT = Stream.HALT
+;
 function Vnode(tag, key, attrs, children, text, dom) {
 	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: {}, events: undefined, instance: undefined}
 }
@@ -786,8 +793,8 @@ var requestService = function($window, log) {
 	function setCompletionCallback(callback) {oncompletion = callback}
 	
 	function xhr(args) {
-		var stream = Stream.stream()
-		if (args.initialValue !== undefined) stream(args.initialValue)
+		var stream2 = Stream.stream()
+		if (args.initialValue !== undefined) stream2(args.initialValue)
 		
 		var useBody = typeof args.useBody === "boolean" ? args.useBody : args.method !== "GET" && args.method !== "TRACE"
 		
@@ -816,16 +823,16 @@ var requestService = function($window, log) {
 				try {
 					var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
 					if (xhr.status >= 200 && xhr.status < 300) {
-						stream(cast(args.type, response))
+						stream2(cast(args.type, response))
 					}
 					else {
 						var error = new Error(xhr.responseText)
 						for (var key in response) error[key] = response[key]
-						stream.error(error)
+						stream2.error(error)
 					}
 				}
 				catch (e) {
-					stream.error(e)
+					stream2.error(e)
 				}
 				if (typeof oncompletion === "function") oncompletion()
 			}
@@ -834,23 +841,23 @@ var requestService = function($window, log) {
 		if (useBody) xhr.send(args.data)
 		else xhr.send()
 		
-		return stream
+		return stream2
 	}
 	function jsonp(args) {
-		var stream = Stream.stream()
-		if (args.initialValue !== undefined) stream(args.initialValue)
+		var stream2 = Stream.stream()
+		if (args.initialValue !== undefined) stream2(args.initialValue)
 		
 		var callbackName = args.callbackName || "_mithril_" + Math.round(Math.random() * 1e16) + "_" + callbackCount++
 		var script = $window.document.createElement("script")
 		$window[callbackName] = function(data) {
 			script.parentNode.removeChild(script)
-			stream(cast(args.type, data))
+			stream2(cast(args.type, data))
 			if (typeof oncompletion === "function") oncompletion()
 			delete $window[callbackName]
 		}
 		script.onerror = function() {
 			script.parentNode.removeChild(script)
-			stream.error(new Error("JSONP request failed"))
+			stream2.error(new Error("JSONP request failed"))
 			if (typeof oncompletion === "function") oncompletion()
 			delete $window[callbackName]
 		}
@@ -859,7 +866,7 @@ var requestService = function($window, log) {
 		args.data[args.callbackKey || "callback"] = callbackName
 		script.src = assemble(args.url, args.data)
 		$window.document.documentElement.appendChild(script)
-		return stream
+		return stream2
 	}
 	function interpolate(url, data) {
 		if (data == null) return url
@@ -1134,11 +1141,7 @@ m.withAttr = function(attrName, callback, context) {
 		return callback.call(context || this, attrName in e.currentTarget ? e.currentTarget[attrName] : e.currentTarget.getAttribute(attrName))
 	}
 }
-m.prop = Stream.stream
-m.prop.combine = Stream.combine
-m.prop.reject = Stream.reject
-m.prop.merge = Stream.merge
-m.prop.HALT = Stream.HALT
+m.prop = stream
 m.render = renderService.render
 m.redraw = redrawService.publish
 m.request = requestService.xhr

--- a/stream/index.js
+++ b/stream/index.js
@@ -4,10 +4,10 @@ var log = console.error.bind(console)
 var StreamFactory = require("../util/stream")
 var Stream = StreamFactory(log)
 
-var s = Stream.stream
-s.combine = Stream.combine
-s.reject = Stream.reject
-s.merge = Stream.merge
-s.HALT = Stream.HALT
+var defaultStream = Stream.stream
+defaultStream.combine = Stream.combine
+defaultStream.reject = Stream.reject
+defaultStream.merge = Stream.merge
+defaultStream.HALT = Stream.HALT
 
-module.exports = s
+module.exports = defaultStream

--- a/stream/index.js
+++ b/stream/index.js
@@ -1,13 +1,13 @@
-"use strict";
+"use strict"
 
 var log = console.error.bind(console)
 var StreamFactory = require("../util/stream")
 var Stream = StreamFactory(log)
 
-var stream = Stream.stream;
+var stream = Stream.stream
 stream.combine = Stream.combine
 stream.reject = Stream.reject
 stream.merge = Stream.merge
 stream.HALT = Stream.HALT
 
-module.exports = stream;
+module.exports = stream

--- a/stream/index.js
+++ b/stream/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var log = console.error.bind(console)
+var StreamFactory = require("../util/stream")
+var Stream = StreamFactory(log)
+
+var stream = Stream.stream;
+stream.combine = Stream.combine
+stream.reject = Stream.reject
+stream.merge = Stream.merge
+stream.HALT = Stream.HALT
+
+module.exports = stream;

--- a/stream/index.js
+++ b/stream/index.js
@@ -4,10 +4,10 @@ var log = console.error.bind(console)
 var StreamFactory = require("../util/stream")
 var Stream = StreamFactory(log)
 
-var stream = Stream.stream
-stream.combine = Stream.combine
-stream.reject = Stream.reject
-stream.merge = Stream.merge
-stream.HALT = Stream.HALT
+var s = Stream.stream
+s.combine = Stream.combine
+s.reject = Stream.reject
+s.merge = Stream.merge
+s.HALT = Stream.HALT
 
-module.exports = stream
+module.exports = s


### PR DESCRIPTION
@lhorie 

Here is the pr for https://github.com/lhorie/mithril.js/issues/1239

I moved streams into their own folder and created an index.js file there so that streams can be required in this way:

```js
import stream from 'mithril/stream';
```

If you prefer a root-level stream.js file, I can change that.

The bundler seemed to have trouble recognizing the index.js import, so I had to manually require `./stream/index`, so maybe a future pr can make that work more like commonjs.

I do not believe this can be merged as-is. Not sure what happened, but in the build the streams ended up being numbered `stream1` `stream2` etc.

Anyway, this can be used as a starting point. Any guidance for how to make this cooperate with the rest of the build setup would be appreciated.

**Edit:** Just realized the bundler does not take kindly to reusing variable names, so changing the name to `defaultStream` solved the issue I was having.