### PR TITLE
Add a static `vnode.skip` field

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -326,7 +326,7 @@ module.exports = function($window) {
 		for (var i = start; i < end; i++) {
 			var vnode = vnodes[i]
 			if (vnode != null) {
-				if (vnode.skip) vnode.skip = undefined
+				if (vnode.skip) vnode.skip = false
 				else removeNode(parent, vnode, context, false)
 			}
 		}

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,5 +1,5 @@
 function Vnode(tag, key, attrs, children, text, dom) {
-	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: {}, events: undefined, instance: undefined}
+	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: {}, events: undefined, instance: undefined, skip: false}
 }
 Vnode.normalize = function(node) {
 	if (node instanceof Array) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)


### PR DESCRIPTION
I remember reading that `vnode` fields not defined statically were oversights, so here we are :-)