### PR TITLE
Robust onbeforeremove

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -203,7 +203,7 @@ module.exports = function($window) {
 			else updateComponent(parent, old, vnode, hooks, nextSibling, recycling, ns)
 		}
 		else {
-			removeNode(parent, old, null, false)
+			removeNode(parent, old, null)
 			insertNode(parent, createNode(vnode, hooks, undefined), nextSibling)
 		}
 	}
@@ -265,7 +265,7 @@ module.exports = function($window) {
 			vnode.domSize = vnode.instance.domSize
 		}
 		else if (old.instance != null) {
-			removeNode(parent, old.instance, null, false)
+			removeNode(parent, old.instance, null)
 			vnode.dom = undefined
 			vnode.domSize = 0
 		}
@@ -327,40 +327,47 @@ module.exports = function($window) {
 			var vnode = vnodes[i]
 			if (vnode != null) {
 				if (vnode.skip) vnode.skip = false
-				else removeNode(parent, vnode, context, false)
+				else removeNode(parent, vnode, context)
 			}
 		}
 	}
-	function removeNode(parent, vnode, context, deferred) {
-		if (deferred === false) {
-			var expected = 0, called = 0
-			var callback = function() {
-				if (++called === expected) removeNode(parent, vnode, context, true)
+	function once(f) {
+		var called = false
+		return function() {
+			if (!called) {
+				called = true
+				f()
 			}
-			if (vnode.attrs && vnode.attrs.onbeforeremove) {
-				expected++
-				vnode.attrs.onbeforeremove.call(vnode.state, vnode, callback)
-			}
-			if (typeof vnode.tag !== "string" && vnode.tag.onbeforeremove) {
-				expected++
-				vnode.tag.onbeforeremove.call(vnode.state, vnode, callback)
-			}
-			if (expected > 0) return
 		}
-
-		onremove(vnode)
-		if (vnode.dom) {
-			var count = vnode.domSize || 1
-			if (count > 1) {
-				var dom = vnode.dom
-				while (--count) {
-					parent.removeChild(dom.nextSibling)
+	}
+	function removeNode(parent, vnode, context) {
+		var expected = 1, called = 0
+		if (vnode.attrs && vnode.attrs.onbeforeremove) {
+			expected++
+			vnode.attrs.onbeforeremove.call(vnode.state, vnode, once(continuation))
+		}
+		if (typeof vnode.tag !== "string" && vnode.tag.onbeforeremove) {
+			expected++
+			vnode.tag.onbeforeremove.call(vnode.state, vnode, once(continuation))
+		}
+		continuation()
+		function continuation() {
+			if (++called === expected) {
+				onremove(vnode)
+				if (vnode.dom) {
+					var count = vnode.domSize || 1
+					if (count > 1) {
+						var dom = vnode.dom
+						while (--count) {
+							parent.removeChild(dom.nextSibling)
+						}
+					}
+					if (vnode.dom.parentNode != null) parent.removeChild(vnode.dom)
+					if (context != null && vnode.domSize == null && !hasIntegrationMethods(vnode.attrs) && typeof vnode.tag === "string") { //TODO test custom elements
+						if (!context.pool) context.pool = [vnode]
+						else context.pool.push(vnode)
+					}
 				}
-			}
-			if (vnode.dom.parentNode != null) parent.removeChild(vnode.dom)
-			if (context != null && vnode.domSize == null && !hasIntegrationMethods(vnode.attrs) && typeof vnode.tag === "string") { //TODO test custom elements
-				if (!context.pool) context.pool = [vnode]
-				else context.pool.push(vnode)
 			}
 		}
 	}

--- a/render/tests/test-onremove.js
+++ b/render/tests/test-onremove.js
@@ -145,4 +145,15 @@ o.spec("onremove", function() {
 
 		o(vnode.dom).notEquals(updated.dom)
 	})
+	o("The remove phase is finalized only once when `done()` is called synchronously from both attrs- and tag.onbeforeremove", function () {
+		var onremove = o.spy()
+		var component = {
+			view: function(){return m('br')},
+			onbeforeremove: function(vnode, done){done()},
+			onremove: onremove
+		}
+		render(root, [{tag: component, attrs: component}])
+		render(root, [])
+		o(onremove.callCount).equals(2)
+	})
 })


### PR DESCRIPTION
This is best viewed with `?w=1` to ignore indentation changes.

Without this, it is possible to run each `onremove` hook twice if a component has the `done()` callback called synchronously from the `attrs.onbeforeremove` hook.

There may be better ways to implement this, I did what seemed the simplest to me.