### PR TITLE
Better cleanup when unmounting

### DIFF
--- a/api/mount.js
+++ b/api/mount.js
@@ -2,24 +2,23 @@
 
 var Vnode = require("../render/vnode")
 var autoredraw = require("../api/autoredraw")
-var dummy = {view: function() {}}
 
 module.exports = function(renderer, pubsub) {
 	return function(root, component) {
 		pubsub.unsubscribe(root.redraw)
+		if (component === null) {
+			renderer.render(root, [])
+			delete root.redraw
+			return
+		}
 
 		var run = autoredraw(root, renderer, pubsub, function() {
 			renderer.render(
 				root,
-				Vnode(component === null ? dummy : component, undefined, undefined, undefined, undefined, undefined)
+				Vnode(component, undefined, undefined, undefined, undefined, undefined)
 			)
 		})
 
 		run()
-
-		if (component === null) {
-			pubsub.unsubscribe(root.redraw)
-			delete root.redraw
-		}
 	}
 }


### PR DESCRIPTION
No need to create a dummy vnode.