### PR TITLE
Add `m.fragment()`

### DIFF
--- a/hyperscript.js
+++ b/hyperscript.js
@@ -1,0 +1,6 @@
+var hyperscript = require("./render/hyperscript")
+hyperscript.trust = require("./render/trust")
+hyperscript.fragment = require("./render/fragment")
+
+
+module.exports = hyperscript

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict"
 
-var m = require("./render/hyperscript")
+var m = require("./hyperscript")
 var renderService = require("./render")
 var requestService = require("./request")
 var redrawService = require("./redraw")
@@ -9,7 +9,6 @@ requestService.setCompletionCallback(redrawService.publish)
 
 m.route = require("./route")
 m.mount = require("./mount")
-m.trust = require("./render/trust")
 m.withAttr = require("./util/withAttr")
 m.prop = require("./stream")
 m.render = renderService.render

--- a/render/fragment.js
+++ b/render/fragment.js
@@ -1,0 +1,7 @@
+"use strict"
+
+var Vnode = require("../render/vnode")
+
+module.exports = function(attrs, children) {
+	return Vnode("[", attrs.key, attrs, Vnode.normalizeChildren(children), undefined, undefined)
+}

--- a/render/tests/test-fragment.js
+++ b/render/tests/test-fragment.js
@@ -1,0 +1,35 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var fragment = require("../../render/fragment")
+
+o.spec("fragment", function() {
+	o("works", function() {
+		var attrs = {foo: 5}
+		var child = {tag: "p"}
+		var frag = fragment(attrs, [child])
+
+		o(frag.tag).equals("[")
+
+		o(frag.children instanceof Array).equals(true)
+		o(frag.children.length).equals(1)
+		o(frag.children[0]).equals(child)
+
+		o(frag.attrs).equals(attrs)
+
+		o(frag.key).equals(undefined)
+	})
+	o("supports keys", function() {
+		var attrs = {key: 7}
+		var frag = fragment(attrs, [])
+		o(frag.tag).equals("[")
+
+		o(frag.children instanceof Array).equals(true)
+		o(frag.children.length).equals(0)
+
+		o(frag.attrs).equals(attrs)
+		o(frag.attrs.key).equals(7)
+
+		o(frag.key).equals(7)
+	})
+})


### PR DESCRIPTION
As announced in #1241, I've also added `./hyperscript`, which combines `render/hyperscript`, `render.raw` and `render.fragment`.