### PR TITLE
Ensure dynamic routes resolve at most once

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -12,9 +12,13 @@ module.exports = function($window, renderer, pubsub) {
 			args.path = path, args.route = route
 			if (typeof payload.onmatch === "function") {
 				if (typeof payload.view !== "function") payload.view = function(vnode) {return vnode}
+				var resolved = false
 				var resolve = function(component) {
-					current.path = path, current.component = component
-					renderer.render(root, payload.view(Vnode(component, null, args, undefined, undefined, undefined)))
+					if (!resolved){
+						current.path = path, current.component = component
+						renderer.render(root, payload.view(Vnode(component, null, args, undefined, undefined, undefined)))
+						resolved = true
+					}
 				}
 				if (path !== current.path) payload.onmatch(Vnode(payload, null, args, undefined, undefined, undefined), resolve)
 				else resolve(current.component)
@@ -31,6 +35,6 @@ module.exports = function($window, renderer, pubsub) {
 	route.prefix = router.setPrefix
 	route.set = router.setPath
 	route.get = router.getPath
-	
+
 	return route
 }

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -45,7 +45,7 @@ o.spec("route", function() {
 
 					callAsync(function() {
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					})
 				})
@@ -62,11 +62,11 @@ o.spec("route", function() {
 
 					setTimeout(function() {
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						$window.history.back()
-						
+
 						o($window.location.pathname).equals("/")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
@@ -84,7 +84,7 @@ o.spec("route", function() {
 
 					function init(vnode) {
 						o(vnode.attrs.foo).equals(undefined)
-						
+
 						done()
 					}
 				})
@@ -226,11 +226,11 @@ o.spec("route", function() {
 						root.firstChild.dispatchEvent(e)
 
 						o($window.location.href).equals(env.protocol + "//" + (env.hostname === "/" ? "" : env.hostname) + slash + (prefix ? prefix + "/" : "") + "test")
-						
+
 						done()
 					})
 				})
-				
+
 				o("accepts RouteResolver", function(done) {
 					var matchCount = 0
 					var renderCount = 0
@@ -239,38 +239,38 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
 							onmatch: function(vnode, resolve) {
 								matchCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
 								o(vnode.attrs.path).equals("/abc")
 								o(vnode.attrs.route).equals("/:id")
-								
+
 								resolve(Component)
 							},
 							view: function(vnode) {
 								renderCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
-								
+
 								return vnode
 							},
 						},
 					})
-					
+
 					setTimeout(function() {
 						o(matchCount).equals(1)
 						o(renderCount).equals(1)
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
-				
+
 				o("accepts RouteResolver without `view` method as payload", function(done) {
 					var matchCount = 0
 					var Component = {
@@ -278,31 +278,62 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
 							onmatch: function(vnode, resolve) {
 								matchCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
 								o(vnode.attrs.path).equals("/abc")
 								o(vnode.attrs.route).equals("/:id")
-								
+
 								resolve(Component)
 							},
 						},
 					})
-					
+
 					setTimeout(function() {
 						o(matchCount).equals(1)
-						
+
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
-				
+
+				o("onmatch resolution callback resolves at most once", function(done) {
+					var resolveCount = 0
+					var Component = {
+						view: function() {
+							resolveCount++
+
+							return m("div")
+						}
+					}
+
+					$window.location.href = prefix + "/"
+					route(root, "/", {
+						"/" : {
+							onmatch: function(vnode, resolve) {
+								resolve(Component)
+								resolve(Component)
+							}
+						},
+					})
+
+					callAsync(function() {
+						o(resolveCount).equals(1)
+
+						setTimeout(function() {
+							o(resolveCount).equals(1)
+
+							done()
+						}, FRAME_BUDGET)
+					})
+				})
+
 				o("object without `onmatch` method acts as component", function(done) {
 					var renderCount = 0
 					var Component = {
@@ -310,23 +341,23 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
 							view: function(vnode) {
 								renderCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
-								
+
 								return m(Component)
 							},
 						},
 					})
-					
+
 					setTimeout(function() {
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
@@ -339,7 +370,7 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/", {
 						"/" : {
@@ -357,13 +388,13 @@ o.spec("route", function() {
 					callAsync(function() {
 						o(matchCount).equals(1)
 						o(renderCount).equals(1)
-						
+
 						redraw.publish()
 
 						setTimeout(function() {
 							o(matchCount).equals(1)
 							o(renderCount).equals(2)
-							
+
 							done()
 						}, FRAME_BUDGET)
 					})


### PR DESCRIPTION
Sloppy code could allow multiple route resolutions, potentially after the user has navigated away from the matched route.