### PR TITLE
Fix propensity to race conditions when using the router (includes #1259).

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -12,9 +12,13 @@ module.exports = function($window, renderer, pubsub) {
 			args.path = path, args.route = route
 			if (typeof payload.onmatch === "function") {
 				if (typeof payload.view !== "function") payload.view = function(vnode) {return vnode}
+				var resolved = false
 				var resolve = function(component) {
-					current.path = path, current.component = component
-					renderer.render(root, payload.view(Vnode(component, null, args, undefined, undefined, undefined)))
+					if (!resolved){
+						current.path = path, current.component = component
+						renderer.render(root, payload.view(Vnode(component, null, args, undefined, undefined, undefined)))
+						resolved = true
+					}
 				}
 				if (path !== current.path) payload.onmatch(Vnode(payload, null, args, undefined, undefined, undefined), resolve)
 				else resolve(current.component)
@@ -31,6 +35,6 @@ module.exports = function($window, renderer, pubsub) {
 	route.prefix = router.setPrefix
 	route.set = router.setPath
 	route.get = router.getPath
-	
+
 	return route
 }

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -243,16 +243,16 @@ o.spec("route", function() {
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
-							onmatch: function(vnode, resolve) {
+							onmatch: function(resolve, attrs, path, route) {
 								matchCount++
-
-								o(vnode.attrs.id).equals("abc")
-								o(vnode.attrs.path).equals("/abc")
-								o(vnode.attrs.route).equals("/:id")
-
+								
+								o(attrs.id).equals("abc")
+								o(path).equals("/abc")
+								o(route).equals("/:id")
+								
 								resolve(Component)
 							},
-							view: function(vnode) {
+							render: function(vnode) {
 								renderCount++
 
 								o(vnode.attrs.id).equals("abc")
@@ -270,8 +270,8 @@ o.spec("route", function() {
 						done()
 					}, FRAME_BUDGET)
 				})
-
-				o("accepts RouteResolver without `view` method as payload", function(done) {
+				
+				o("accepts RouteResolver without `render` method as payload", function(done) {
 					var matchCount = 0
 					var Component = {
 						view: function() {
@@ -282,13 +282,13 @@ o.spec("route", function() {
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
-							onmatch: function(vnode, resolve) {
+							onmatch: function(resolve, attrs, path, route) {
 								matchCount++
-
-								o(vnode.attrs.id).equals("abc")
-								o(vnode.attrs.path).equals("/abc")
-								o(vnode.attrs.route).equals("/:id")
-
+								
+								o(attrs.id).equals("abc")
+								o(path).equals("/abc")
+								o(route).equals("/:id")
+								
 								resolve(Component)
 							},
 						},
@@ -316,7 +316,7 @@ o.spec("route", function() {
 					$window.location.href = prefix + "/"
 					route(root, "/", {
 						"/" : {
-							onmatch: function(vnode, resolve) {
+							onmatch: function(resolve) {
 								resolve(Component)
 								resolve(Component)
 							}
@@ -335,6 +335,10 @@ o.spec("route", function() {
 				})
 
 				o("object without `onmatch` method acts as component", function(done) {
+=======
+				
+				o("RouteResolver without `onmatch` hook calls `render` appropriately", function(done) {
+>>>>>>> Adapt router tests
 					var renderCount = 0
 					var Component = {
 						view: function() {
@@ -345,7 +349,7 @@ o.spec("route", function() {
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
-							view: function(vnode) {
+							render: function(vnode) {
 								renderCount++
 
 								o(vnode.attrs.id).equals("abc")
@@ -362,7 +366,7 @@ o.spec("route", function() {
 					}, FRAME_BUDGET)
 				})
 
-				o("calls onmatch and view correct number of times", function(done) {
+				o("calls `onmatch` and `render` correct number of times", function(done) {
 					var matchCount = 0
 					var renderCount = 0
 					var Component = {
@@ -374,11 +378,11 @@ o.spec("route", function() {
 					$window.location.href = prefix + "/"
 					route(root, "/", {
 						"/" : {
-							onmatch: function(vnode, resolve) {
+							onmatch: function(resolve, attrs, path, route) {
 								matchCount++
 								resolve(Component)
 							},
-							view: function(vnode) {
+							render: function(vnode) {
 								renderCount++
 								return vnode
 							},

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -245,11 +245,11 @@ o.spec("route", function() {
 						"/:id" : {
 							onmatch: function(resolve, attrs, path, route) {
 								matchCount++
-								
+
 								o(attrs.id).equals("abc")
 								o(path).equals("/abc")
 								o(route).equals("/:id")
-								
+
 								resolve(Component)
 							},
 							render: function(vnode) {
@@ -270,7 +270,7 @@ o.spec("route", function() {
 						done()
 					}, FRAME_BUDGET)
 				})
-				
+
 				o("accepts RouteResolver without `render` method as payload", function(done) {
 					var matchCount = 0
 					var Component = {
@@ -284,11 +284,11 @@ o.spec("route", function() {
 						"/:id" : {
 							onmatch: function(resolve, attrs, path, route) {
 								matchCount++
-								
+
 								o(attrs.id).equals("abc")
 								o(path).equals("/abc")
 								o(route).equals("/:id")
-								
+
 								resolve(Component)
 							},
 						},
@@ -334,11 +334,7 @@ o.spec("route", function() {
 					})
 				})
 
-				o("object without `onmatch` method acts as component", function(done) {
-=======
-				
 				o("RouteResolver without `onmatch` hook calls `render` appropriately", function(done) {
->>>>>>> Adapt router tests
 					var renderCount = 0
 					var Component = {
 						view: function() {
@@ -402,6 +398,44 @@ o.spec("route", function() {
 							done()
 						}, FRAME_BUDGET)
 					})
+				})
+				o("route.set(route.get()) triggers `onmatch()`", function(done){
+					var matchCount = 0
+					var renderCount = 0
+					var Component = {
+						view: function() {
+							return m("div")
+						}
+					}
+
+					$window.location.href = prefix + "/"
+					route(root, "/", {
+						"/" : {
+							onmatch: function(resolve, attrs, path, route) {
+								matchCount++
+								resolve(Component)
+							},
+							render: function(vnode) {
+								renderCount++
+								return vnode
+							},
+						},
+					})
+
+					callAsync(function() {
+						o(matchCount).equals(1)
+						o(renderCount).equals(1)
+
+						route.set(route.get())
+
+						setTimeout(function() {
+							o(matchCount).equals(2)
+							o(renderCount).equals(2)
+
+							done()
+						}, FRAME_BUDGET)
+					})
+
 				})
 			})
 		})

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -45,7 +45,7 @@ o.spec("route", function() {
 
 					callAsync(function() {
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					})
 				})
@@ -62,11 +62,11 @@ o.spec("route", function() {
 
 					setTimeout(function() {
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						$window.history.back()
-						
+
 						o($window.location.pathname).equals("/")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
@@ -84,7 +84,7 @@ o.spec("route", function() {
 
 					function init(vnode) {
 						o(vnode.attrs.foo).equals(undefined)
-						
+
 						done()
 					}
 				})
@@ -226,11 +226,11 @@ o.spec("route", function() {
 						root.firstChild.dispatchEvent(e)
 
 						o($window.location.href).equals(env.protocol + "//" + (env.hostname === "/" ? "" : env.hostname) + slash + (prefix ? prefix + "/" : "") + "test")
-						
+
 						done()
 					})
 				})
-				
+
 				o("accepts RouteResolver", function(done) {
 					var matchCount = 0
 					var renderCount = 0
@@ -239,38 +239,38 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
 							onmatch: function(vnode, resolve) {
 								matchCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
 								o(vnode.attrs.path).equals("/abc")
 								o(vnode.attrs.route).equals("/:id")
-								
+
 								resolve(Component)
 							},
 							view: function(vnode) {
 								renderCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
-								
+
 								return vnode
 							},
 						},
 					})
-					
+
 					setTimeout(function() {
 						o(matchCount).equals(1)
 						o(renderCount).equals(1)
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
-				
+
 				o("accepts RouteResolver without `view` method as payload", function(done) {
 					var matchCount = 0
 					var Component = {
@@ -278,31 +278,62 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
 							onmatch: function(vnode, resolve) {
 								matchCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
 								o(vnode.attrs.path).equals("/abc")
 								o(vnode.attrs.route).equals("/:id")
-								
+
 								resolve(Component)
 							},
 						},
 					})
-					
+
 					setTimeout(function() {
 						o(matchCount).equals(1)
-						
+
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
-				
+
+				o("onmatch resolution callback resolves at most once", function(done) {
+					var resolveCount = 0
+					var Component = {
+						view: function() {
+							resolveCount++
+
+							return m("div")
+						}
+					}
+
+					$window.location.href = prefix + "/"
+					route(root, "/", {
+						"/" : {
+							onmatch: function(vnode, resolve) {
+								resolve(Component)
+								resolve(Component)
+							}
+						},
+					})
+
+					callAsync(function() {
+						o(resolveCount).equals(1)
+
+						setTimeout(function() {
+							o(resolveCount).equals(1)
+
+							done()
+						}, FRAME_BUDGET)
+					})
+				})
+
 				o("object without `onmatch` method acts as component", function(done) {
 					var renderCount = 0
 					var Component = {
@@ -310,23 +341,23 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/abc", {
 						"/:id" : {
 							view: function(vnode) {
 								renderCount++
-								
+
 								o(vnode.attrs.id).equals("abc")
-								
+
 								return m(Component)
 							},
 						},
 					})
-					
+
 					setTimeout(function() {
 						o(root.firstChild.nodeName).equals("DIV")
-						
+
 						done()
 					}, FRAME_BUDGET)
 				})
@@ -339,7 +370,7 @@ o.spec("route", function() {
 							return m("div")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
 					route(root, "/", {
 						"/" : {
@@ -357,13 +388,13 @@ o.spec("route", function() {
 					callAsync(function() {
 						o(matchCount).equals(1)
 						o(renderCount).equals(1)
-						
+
 						redraw.publish()
 
 						setTimeout(function() {
 							o(matchCount).equals(1)
 							o(renderCount).equals(2)
-							
+
 							done()
 						}, FRAME_BUDGET)
 					})


### PR DESCRIPTION
AFAICT this fixes potential race conditions when calling `m.route()` several times while a `onmatch(resolve)` is pending or when redrawing between a route request (`route.set()`, `route.link()`) and a route resolution.

As discussed with Leo, this restores the `RouteResolver` API to it's initial self, with `resolve(use, ...)` renamed to `onmatch(resolve, ...)` so that we don't reserve params/attrs names for the framework.

TODO: 
- Add test for the various race conditions :-)
- Update the docs

Note that I also have a `mount`-based version of this in the works where:

- `mount` is augmented to take `attrs`,
- `autoredraw` uses a new `pubsub.swap` to ensure that root elements are redrawn in the order they were initially mounted
- the router uses a small component to perform the `RouteResolver.render` duties.

However, it is buggy at this point, the tests fail in mysterious ways and it is getting late here and I won't debug it until later. 

@lhorie you may want to wait for that PR to compare both approaches. This isn't ready for a merge either   at this point, I'll add the missing tests hopefully tomorrow.