### PR TITLE
fix typo in RouteResolver description

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -266,7 +266,7 @@ m.route.prefix("/my-app")
 
 ### Advanced component resolution
 
-Instead of mapping a component to a route, you can specify a RouteResolver object. A RouteResolver object contains a `onmatch()` method and a optionally a `view()` method.
+Instead of mapping a component to a route, you can specify a RouteResolver object. A RouteResolver object contains a `onmatch()` method and a optionally a `render()` method.
 
 ```javascript
 m.route(document.body, "/", {


### PR DESCRIPTION
..unless the code sample is wrong, in which case `render:` should be replaced with `view:`