### PR TITLE
[rewrite] Add pending test for oncreate bug

### DIFF
--- a/render/tests/test-oncreate.js
+++ b/render/tests/test-oncreate.js
@@ -68,6 +68,27 @@ o.spec("oncreate", function() {
 		o(createA.this).equals(updated.state)
 		o(createA.args[0]).equals(updated)
 	})
+	o("calls oncreate when key changes", function() {
+
+		return console.log('Pending test (TODO: Delete this line)')
+
+		var create = o.spy()
+		var vnode = {tag: "div", state: {}, children: [
+			{tag: "div", state: {}},
+			{tag: "div", key: 1, state: {}},
+		]}
+		var updated = {tag: "div", state: {}, children:[
+			{tag: "div", state: {}},
+			{tag: "div", key: 2, attrs: {oncreate: create}, state:{}},
+		]}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		o(create.callCount).equals(1)
+		o(create.this).equals(updated.children[0].state)
+		o(create.args[0]).equals(updated.children[0])
+	})
 	o("does not call oncreate when noop", function() {
 		var create = o.spy()
 		var update = o.spy()


### PR DESCRIPTION
I discovered a bug when attempting to implement tabs in mithril rewrite. Strangely, if you delete the empty, first-child div in both `vnode` and `updated` within the test, it works.

I left the test as "pending" to avoid breaking the CI.