### PR TITLE
[rewrite] Log full stack for unhandled stream errors

### DIFF
--- a/util/stream.js
+++ b/util/stream.js
@@ -98,7 +98,7 @@ module.exports = function(log) {
 	function reportUncaughtError(stream, e) {
 		if (Object.keys(stream._state.deps).length === 0) {
 			setTimeout(function() {
-				if (Object.keys(stream._state.deps).length === 0) log(e)
+				if (Object.keys(stream._state.deps).length === 0) log(e.stack)
 			}, 0)
 		}
 	}

--- a/util/tests/test-stream.js
+++ b/util/tests/test-stream.js
@@ -852,11 +852,11 @@ o.spec("stream", function() {
 	})
 	o.spec("uncaught exception reporting", function() {
 		o("reports thrown errors", function(done) {
-			Stream(1).map(function() {throw new Error("error")})
+			Stream(1).map(function() {throw new Error("my message")})
 			
 			setTimeout(function() {
 				o(spy.callCount).equals(1)
-				o(spy.args[0].message).equals("error")
+				o( !! spy.args[0].split('\n')[0].match(/my message/) ).equals(true)
 				done()
 			}, 0)
 		})


### PR DESCRIPTION
First of all, this feature is awesome! I just ran into a situation where I would have been totally clueless if this didn't exist.

I updated it to report the full stack trace. Currently it is only reporting the message of the error, with no line numbers.