### PR TITLE
[ospec] allow spy to wrap functions

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -19,11 +19,14 @@ module.exports = new function init() {
 		ctx = parent
 	}
 	o.only = function(subject, predicate) {o(subject, only = predicate)}
-	o.spy = function() {
+	o.spy = function(fn) {
 		var spy = function() {
 			spy.this = this
 			spy.args = [].slice.call(arguments)
 			spy.callCount++
+
+			if(fn)
+				return fn.apply(this, arguments)
 		}
 		spy.args = []
 		spy.callCount = 0

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -49,6 +49,23 @@ o.spec("ospec", function() {
 			o(spy.args.length).equals(1)
 			o(spy.args[0]).equals(1)
 		})
+		o("spy wrapping", function() {
+			var spy = o.spy(function view(vnode){
+				this.drawn = true
+
+				return {tag: "div", children: vnode.children}
+			})
+			var children = [""]
+			var state = {}
+
+			var output = spy.call(state, {children: children})
+
+			o(spy.callCount).equals(1)
+			o(spy.args.length).equals(1)
+			o(spy.args[0]).deepEquals({children: children})
+			o(state).deepEquals({drawn: true})
+			o(output).deepEquals({tag: "div", children: children})
+		})
 	})
 	o.spec("async", function() {
 		var a = 0, b = 0


### PR DESCRIPTION
Currently tests need to take a very different approach as soon as you need to ensure that a function was called but also have that function fulfil its own arbitrary functionality.

This re-introduces the valuable ability to allow spying on functions whose side effects and return values the tests may depend on.