### PR TITLE
[rewrite] Remove redundant lines that break the examples

### DIFF
--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -65,7 +65,4 @@ function hyperscript(selector) {
 	return Vnode(selector, attrs && attrs.key, attrs || {}, Vnode.normalizeChildren(children), undefined, undefined)
 }
 
-hyperscript.trust = require("./trust")
-hyperscript.fragment = require("./fragment")
-
 module.exports = hyperscript


### PR DESCRIPTION
This is already covered [here](https://github.com/lhorie/mithril.js/blob/9fbcea2d067ef3f28877c626c10f33a2643345fd/hyperscript.js).

Non-bundle examples are broken by the lines removed here (since they don't load `render/trust.js` and `render/fragment.js`). I could have fixed them, but this is easier :-)