### PR TITLE
[rewrite] m.route API design proposal

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -47,7 +47,7 @@ module.exports = function($window, mount) {
 			var result = render(newRoute, reject)
 
 			if ( result === reject ) {
-				newRoute.tryAgain = tryAgainFn(newRoute, currentRoute)
+				newRoute.retry = retryFn(newRoute, currentRoute)
 			}
 
 			if (result !== reject) {
@@ -78,7 +78,7 @@ module.exports = function($window, mount) {
 		})
 	}
 
-	function tryAgainFn (rejectedRoute, originalRoute) {
+	function retryFn (rejectedRoute, originalRoute) {
 		// Provide a pre-filled router.setPath function that only works
 		// if the route has not been changed by something else.
 		return function () {

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -395,7 +395,7 @@ o.spec("route", function() {
 					}
 				})
 
-				o("route.tryAgain()", function(done, timeout) {
+				o("route.retry()", function(done, timeout) {
 					timeout(FRAME_BUDGET * 5)
 					var view1Count = 0
 					var view2Count = 0
@@ -413,7 +413,7 @@ o.spec("route", function() {
 
 								setTimeout(function(){
 									asyncResource = 'h2'
-									route.tryAgain()
+									route.retry()
 								}, FRAME_BUDGET)
 
 								return reject
@@ -472,7 +472,7 @@ o.spec("route", function() {
 
 								setTimeout(function mockLoad () {
 									asyncResource = 'h2'
-									route.tryAgain()
+									route.retry()
 								}, FRAME_BUDGET*3)
 
 								rejected = true

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -8,13 +8,14 @@ var m = require("../../render/hyperscript")
 var coreRenderer = require("../../render/render")
 var apiPubSub = require("../../api/pubsub")
 var apiRouter = require("../../api/router")
+var apiMounter = require("../../api/mount")
 
 o.spec("route", function() {
 	void [{protocol: "http:", hostname: "localhost"}, {protocol: "file:", hostname: "/"}].forEach(function(env) {
 		void ["#", "?", "", "#!", "?!", "/foo"].forEach(function(prefix) {
 			o.spec("using prefix `" + prefix + "` starting on " + env.protocol + "//" + env.hostname, function() {
 				var FRAME_BUDGET = Math.floor(1000 / 60)
-				var $window, root, redraw, route
+				var $window, root, redraw, mount, routeLib
 
 				o.beforeEach(function() {
 					$window = browserMock(env)
@@ -22,13 +23,14 @@ o.spec("route", function() {
 					root = $window.document.body
 
 					redraw = apiPubSub()
-					route = apiRouter($window, coreRenderer($window), redraw)
-					route.prefix(prefix)
+					mount = apiMounter(coreRenderer($window), redraw)
+					routeLib = apiRouter($window, mount)
+					routeLib.prefix(prefix)
 				})
 
 				o("renders into `root`", function(done) {
 					$window.location.href = prefix + "/"
-					route(root, "/", {
+					routeLib(root, "/", {
 						"/" : {
 							view: function() {
 								return m("div")
@@ -45,7 +47,7 @@ o.spec("route", function() {
 
 				o("default route doesn't break back button", function(done) {
 					$window.location.href = "http://google.com"
-					route(root, "/a", {
+					routeLib(root, "/a", {
 						"/a" : {
 							view: function() {
 								return m("div")
@@ -66,7 +68,7 @@ o.spec("route", function() {
 
 				o("default route does not inherit params", function(done) {
 					$window.location.href = "/invalid?foo=bar"
-					route(root, "/a", {
+					routeLib(root, "/a", {
 						"/a" : {
 							oninit: init,
 							view: function() {
@@ -87,7 +89,7 @@ o.spec("route", function() {
 					var oninit = o.spy()
 
 					$window.location.href = prefix + "/"
-					route(root, "/", {
+					routeLib(root, "/", {
 						"/" : {
 							view: function() {
 								return m("div", {
@@ -121,7 +123,7 @@ o.spec("route", function() {
 					e.initEvent("click", true, true)
 
 					$window.location.href = prefix + "/"
-					route(root, "/", {
+					routeLib(root, "/", {
 						"/" : {
 							view: function() {
 								return m("div", {
@@ -161,7 +163,7 @@ o.spec("route", function() {
 					e.initEvent("click", true, true)
 
 					$window.location.href = prefix + "/"
-					route(root, "/", {
+					routeLib(root, "/", {
 						"/" : {
 							view: function() {
 								return m("div", {
@@ -195,12 +197,12 @@ o.spec("route", function() {
 					e.initEvent("click", true, true)
 
 					$window.location.href = prefix + "/"
-					route(root, "/", {
+					routeLib(root, "/", {
 						"/" : {
 							view: function() {
 								return m("a", {
 									href: "/test",
-									oncreate: route.link
+									oncreate: routeLib.link
 								})
 							}
 						},
@@ -224,125 +226,89 @@ o.spec("route", function() {
 					})
 				})
 				
-				o("accepts RouteResolver", function(done) {
-					var matchCount = 0
+				o("accepts a route function", function(done) {
 					var renderCount = 0
 					var Component = {
 						view: function() {
-							return m("div")
+							return m("h1")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
-					route(root, "/abc", {
-						"/:id" : {
-							onmatch: function(vnode, resolve) {
-								matchCount++
-								
-								o(vnode.attrs.id).equals("abc")
-								o(route.get()).equals("/abc")
-								
-								resolve(Component)
-							},
-							render: function(vnode) {
-								renderCount++
-								
-								o(vnode.attrs.id).equals("abc")
-								
-								return vnode
-							},
-						},
+					routeLib(root, "/abc", {
+						"/:id" : function (route) {
+							renderCount++
+							o(route.args.id).equals("abc")
+							o(route.path).equals("/abc")
+							o(routeLib.get()).equals("/abc")
+
+							return m(Component, route.args)
+						}
 					})
-					
+
+
 					setTimeout(function() {
-						o(matchCount).equals(1)
 						o(renderCount).equals(1)
-						o(root.firstChild.nodeName).equals("DIV")
-						
+						o(root.firstChild.nodeName).equals("H1")
+
 						done()
 					}, FRAME_BUDGET)
 				})
-				
-				o("accepts RouteResolver without `render` method as payload", function(done) {
-					var matchCount = 0
-					var Component = {
-						view: function() {
-							return m("div")
-						}
-					}
-					
-					$window.location.href = prefix + "/"
-					route(root, "/abc", {
-						"/:id" : {
-							onmatch: function(vnode, resolve) {
-								matchCount++
-								
-								o(vnode.attrs.id).equals("abc")
-								o(route.get()).equals("/abc")
-								
-								resolve(Component)
-							},
-						},
-					})
-					
-					setTimeout(function() {
-						o(matchCount).equals(1)
-						
-						o(root.firstChild.nodeName).equals("DIV")
-						
-						done()
-					}, FRAME_BUDGET)
-				})
-				
-				o("accepts RouteResolver without `onmatch` method as payload", function(done) {
+
+				o("accepts a route function with a reject parameter", function(done, timeout) {
+					var rejectCount = 0
 					var renderCount = 0
 					var Component = {
 						view: function() {
-							return m("div")
+							return m("H1")
 						}
 					}
-					
+
 					$window.location.href = prefix + "/"
-					route(root, "/abc", {
-						"/:id" : {
-							render: function(vnode) {
-								renderCount++
-								
-								o(vnode.attrs.id).equals("abc")
-								
-								return m(Component)
-							},
-						},
+					routeLib(root, "/abc", {
+						"/:id" : function (route, reject) {
+							if ( rejectCount === 0 ) {
+								rejectCount++
+								return reject
+							}
+							renderCount++
+							o(route.args.id).equals("abc")
+							o(routeLib.get()).equals("/abc")
+
+							return m(Component, route.args)
+						}
 					})
-					
+
 					setTimeout(function() {
+						o(rejectCount).equals(1)
+						o(renderCount).equals(0)
 						o(root.firstChild.nodeName).equals("DIV")
-						
-						done()
+
+						redraw.publish()
+
+						callAsync(function() {
+							o(rejectCount).equals(1)
+							o(renderCount).equals(1)
+							o(root.firstChild.nodeName).equals("H1")
+
+							done()
+						})
+
 					}, FRAME_BUDGET)
 				})
-				
-				o("RouteResolver `render` does not have component semantics", function(done, timeout) {
+
+				o("route function does not have component semantics", function(done, timeout) {
 					timeout(60)
 					
 					var renderCount = 0
-					var A = {
-						view: function() {
-							return m("div")
-						}
-					}
 					
 					$window.location.href = prefix + "/"
-					route(root, "/a", {
-						"/a" : {
-							render: function(vnode) {
-								return m("div")
-							},
+					routeLib(root, "/a", {
+						"/a" : function(route) {
+							return m("div")
 						},
-						"/b" : {
-							render: function(vnode) {
-								return m("div")
-							},
+						"/b" : function(route) {
+							return m("div")
 						},
 					})
 					
@@ -350,7 +316,7 @@ o.spec("route", function() {
 						var dom = root.firstChild
 						o(root.firstChild.nodeName).equals("DIV")
 						
-						route.set("/b")
+						routeLib.set("/b")
 						
 						setTimeout(function() {
 							o(root.firstChild).equals(dom)
@@ -360,147 +326,223 @@ o.spec("route", function() {
 					}, FRAME_BUDGET)
 				})
 
-				o("calls onmatch and view correct number of times", function(done) {
-					var matchCount = 0
-					var renderCount = 0
-					var Component = {
-						view: function() {
-							return m("div")
-						}
-					}
-					
-					$window.location.href = prefix + "/"
-					route(root, "/", {
-						"/" : {
-							onmatch: function(vnode, resolve) {
-								matchCount++
-								resolve(Component)
-							},
-							render: function(vnode) {
-								renderCount++
-								return vnode
-							},
-						},
-					})
+				o("render function can redirect to another route", function(done) {
+						var redirected = false
 
-					callAsync(function() {
-						o(matchCount).equals(1)
-						o(renderCount).equals(1)
-						
-						redraw.publish()
+						$window.location.href = prefix + "/"
+						routeLib(root, "/a", {
+							"/a" : function (params, reject) {
+								routeLib.set("/b")
+								return reject
+							},
+							"/b" : function(params){
+								redirected = true
+							}
+						})
 
 						setTimeout(function() {
-							o(matchCount).equals(1)
-							o(renderCount).equals(2)
-							
+							o(redirected).equals(true)
+
 							done()
 						}, FRAME_BUDGET)
-					})
 				})
-				
-				o("onmatch can redirect to another route", function(done) {
-                    var redirected = false
 
-                    $window.location.href = prefix + "/"
-                    route(root, "/a", {
-                        "/a" : {
-                            onmatch: function() {
-                                route.set("/b")
-                            }
-                        },
-                        "/b" : {
-                            view: function(vnode){
-                                redirected = true
-                            }
-                        }
-                    })
-
-                    setTimeout(function() {
-                        o(redirected).equals(true)
-
-                        done()
-                    }, FRAME_BUDGET)
-                })
-				
-				o("onmatch can redirect to another route that has RouteResolver", function(done) {
-                    var redirected = false
-
-                    $window.location.href = prefix + "/"
-                    route(root, "/a", {
-                        "/a" : {
-                            onmatch: function() {
-                                route.set("/b")
-                            }
-                        },
-                        "/b" : {
-                            render: function(vnode){
-                                redirected = true
-                            }
-                        }
-                    })
-
-                    setTimeout(function() {
-                        o(redirected).equals(true)
-
-                        done()
-                    }, FRAME_BUDGET)
-                })
-				
-				o("onmatch resolution callback resolves at most once", function(done) {
-					var resolveCount = 0
-					var resolvedComponent
-					var A = {view: function() {}}
-					var B = {view: function() {}}
-					var C = {view: function() {}}
+				o("render function can redirect back to previous route", function(done, timeout) {
+					timeout(FRAME_BUDGET * 4)
+					var view1Count = 0
+					var view2Count = 0
 
 					$window.location.href = prefix + "/"
-					route(root, "/", {
-						"/": {
-							onmatch: function(vnode, resolve) {
-								resolve(A)
-								resolve(B)
-								callAsync(function() {resolve(C)})
-							},
-							render: function(vnode) {
-								resolveCount++
-								resolvedComponent = vnode.tag
-							}
+					routeLib(root, "/v1", {
+						"/v1": function () {
+							view1Count++
+							return m('h1')
 						},
+						"/v2": function (args, reject) {
+							view2Count++
+							return reject
+						}
 					})
+
 					setTimeout(function() {
-						o(resolveCount).equals(1)
-						o(resolvedComponent).equals(A)
+						o(view1Count).equals(1) // Initial route
+						o(view2Count).equals(0)
+						checkState()
+
+						routeLib.set("/v2")
+
+						setTimeout(function(){
+							o(view1Count).equals(2) // Initial route
+							o(view2Count).equals(1) // Reject route
+							checkState()
+
+							// This should redraw the initial route
+							redraw.publish()
+
+							setTimeout(function() {
+								o(view1Count).equals(3) // Initial route
+								o(view2Count).equals(1)
+								checkState()
+
+								done()
+							}, FRAME_BUDGET)
+						}, FRAME_BUDGET)
+					}, FRAME_BUDGET)
+
+					function checkState () {
+						o(root.firstChild.nodeName).equals("H1")
+						o(routeLib.get()).equals("/v1")
+					}
+				})
+
+				o("render function can redirect to a third route", function(done, timeout) {
+					timeout(FRAME_BUDGET * 3)
+					var view1Count = 0
+					var view2Count = 0
+					var view3Count = 0
+
+					$window.location.href = prefix + "/"
+					routeLib(root, "/v1", {
+						"/v1": function () {
+							view1Count++
+							return m('h1')
+						},
+						"/v2": function (args, reject) {
+							view2Count++
+							routeLib.set('/v3')
+							return reject
+						},
+						"/v3": function (args, reject) {
+							view3Count++
+							return m('h2')
+						}
+					})
+
+					setTimeout(function() {
+						o(view1Count).equals(1)
+						o(view2Count).equals(0)
+						o(view3Count).equals(0)
+
+						o(root.firstChild.nodeName).equals("H1")
+						o(routeLib.get()).equals("/v1")
+
+						routeLib.set("/v2")
+
+						setTimeout(function(){
+							o(view1Count).equals(1) // Initial route
+							o(view2Count).equals(1) // Reject route
+							o(view3Count).equals(1) // Detour route
+
+							o(root.firstChild.nodeName).equals("H2")
+							o(routeLib.get()).equals("/v3")
+
+							done()
+						}, FRAME_BUDGET)
+					}, FRAME_BUDGET)
+
+				})
+
+				o("routed mount points can redraw synchronoulsy (#1275)", function(done) {
+					var view = o.spy()
+
+					$window.location.href = prefix + "/"
+					routeLib(root, "/", {"/":{view:view}})
+
+					setTimeout(function() {
+						o(view.callCount).equals(1)
+
+						redraw.publish(true)
+
+						o(view.callCount).equals(2)
 
 						done()
 					}, FRAME_BUDGET)
 				})
-				
-				o("calling route.set invalidates pending onmatch resolution", function(done, timeout) {
-					timeout(100)
-					
-					var resolved
+
+				o("m.routeLib.set(m.routeLib.get()) re-runs the resolution logic (#1180)", function(done, timeout){
+					timeout(FRAME_BUDGET * 3)
+
+					var renderCount = 0
+
 					$window.location.href = prefix + "/"
-					route(root, "/a", {
-						"/a": {
-							onmatch: function(vnode, resolve) {
-								setTimeout(resolve, 20)
-							},
-							render: function(vnode) {resolved = "a"}
-						},
-						"/b": {
-							view: function() {resolved = "b"}
-						}
+					routeLib(root, '/', {
+						"/": { view: function(){
+							renderCount++
+							return m("div")
+						}}
 					})
+
 					setTimeout(function() {
-						route.set("/b")
-						
+						o(renderCount).equals(1)
+
+						routeLib.set(routeLib.get())
+
 						setTimeout(function() {
-							o(resolved).equals("b")
+							o(renderCount).equals(2)
 
 							done()
-						}, 30)
+						}, FRAME_BUDGET)
 					}, FRAME_BUDGET)
 				})
+
+				o("route function has access to previous route", function(done){
+					$window.location.href = prefix + "/"
+
+					var prev = null
+
+					routeLib(root, "/", {
+						"/": function(route){
+							prev = route.prev
+						},
+						"/2": function(route){
+							prev = route.prev
+						}
+					})
+
+
+					setTimeout(function() {
+						o(routeLib.get()).equals("/")
+						o(prev.path).equals(null)
+
+						routeLib.set("/2")
+
+						callAsync(function() {
+							o(routeLib.get()).equals("/2")
+							o(prev.path).equals("/")
+							done()
+						})
+
+					}, FRAME_BUDGET)
+				})
+
+				o("routing with RouteResolver works more than once (#1286)", function(done, timeout){
+					timeout(FRAME_BUDGET * 4)
+
+					$window.location.href = prefix + "/a"
+					routeLib(root, '/a', {
+						'/a': function() {
+							return m("a", "a")
+						},
+						'/b': function() {
+							return m("b", "b")
+						}
+					})
+
+					setTimeout(function(){
+						routeLib.set('/b')
+
+						setTimeout(function(){
+							routeLib.set('/a')
+
+							setTimeout(function(){
+								o(root.firstChild.nodeName).equals("A")
+
+								done()
+							}, FRAME_BUDGET)
+						}, FRAME_BUDGET)
+					}, FRAME_BUDGET)
+				})
+
 			})
 		})
 	})


### PR DESCRIPTION
Here is a proposal for simplifying the router. In this proposal, `onmatch` and `render` are removed in favor of a **route function**, which receives two parameters every redraw. The function can return the second parameter if it wishes to abort drawing and redirect instead.

Here are examples of intended usage:

``` js
m.route(document.getElementById('app'), '/', {

  '/': Home, // Simple usage

  //
  // 1 - Composing components with diff semantics
  //
  '/sign-in': () => withLayout(SignIn),

  '/users/:id', (route) => withLayout(UserPage, route.args),

  //
  // 2a - Code splitting, with a loading screen
  //
  // NOTE: myRequire is based on
  // https://github.com/lhorie/mithril.js/issues/1095#issuecomment-242093355
  //
  // Mithril could potentially support a constructor of this sort
  // e.g.  m.require = require('mithril/async-require')(load)
  //
  '/big-page': function (route) {
    var BigPage = myRequire('profile-settings.js')
    return m(BigPage) || m('Loading...')
  },

  //
  // 2b - Code splitting, but not drawing until ready
  //
  '/graph-page': function (route, reject) {
    var d3 = myRequire('d3', route.retry)
    return d3 ? reject : m(GraphPage)
  },

  //
  // 3a - "Pre-render" hard-coded redirect
  //
  '/profile/settings': function (route, reject) {
    if ( notLoggedIn() ) {
      m.route.set('/sign-in')
      return reject
    }
    return m(ProfileSettings)
  },

  //
  // 3b - "Pre-render" back-button redirect
  //
  '/secret/page': function (route, reject) {
    if ( notAuthorized() ) {
      return reject
    }
    return m(ProfileSettings)
  },

  //
  // 4 - Some way to recreate from scratch on route reload
  //     Not implemented, need advice
  //
  // 5 - route args should always be available for the above use cases
  //     Check! Available via route.path, route.args, and route.prev.path / route.prev.args
  //
  // 6 - All of the features above must be possible to use at the same time within a single route
  //
  '/secret/analytics': (route, reject) => {
    if ( notLoggedIn() ) {
      m.route.set('/login')
      return reject
    }
    else if ( notAuthorized() ) {
      return reject // redirect back to previous route
    }

    var d3 = myRequire('d3')
    return d3 ? reject : m(GraphPage, route.args)
  }
})

function withLayout(Component, args) {
  return m('app', m('nav'), m(Component, args), m('footer'))
}
```

Major credit goes to @pygy for his excellent code as a foundation https://github.com/lhorie/mithril.js/pull/1290 (and, of course, @lhorie for making Mithril modular and so nice to work with 😄 )

If this gets approved, I'm very willing to write the documentation.
