### PR TITLE
WIP - Prevent Infinite Loop in m.prop.combine

### DIFF
--- a/util/stream.js
+++ b/util/stream.js
@@ -116,6 +116,7 @@ module.exports = function(log) {
 		return initDependency(self, [stream], derive, recover)
 	}
 	function combine(fn, streams) {
+		if (streams.length > streams.filter(valid).length) throw new Error("Ensure that each item passed to m.prop.combine/m.prop.merge is a stream")
 		return initDependency(createStream(), streams, function() {
 			var failed = streams.filter(errored)
 			if (failed.length > 0) throw {__error: failed[0]._state.error}
@@ -177,6 +178,7 @@ module.exports = function(log) {
 	function valueOf() {return this._state.value}
 	function toJSON() {return this._state.value != null && typeof this._state.value.toJSON === "function" ? this._state.value.toJSON() : this._state.value}
 
+	function valid(stream) {return stream._state }
 	function active(stream) {return stream._state.state === 1}
 	function changed(stream) {return stream._state.changed}
 	function notEnded(stream) {return stream._state.state !== 2}

--- a/util/tests/test-stream.js
+++ b/util/tests/test-stream.js
@@ -171,6 +171,20 @@ o.spec("stream", function() {
 
 			o(b()).equals(undefined)
 		})
+		o("combine will throw with a helpful error if given non-stream values", function () {
+			var spy = o.spy()
+			var a = Stream(1)
+			var thrown = null;
+			try {
+				var b = Stream.combine(spy, [a, ''])
+			} catch (e) {
+				thrown = e
+			}
+
+			o(thrown).notEquals(null)
+			o(thrown.constructor === TypeError).equals(false)
+			o(spy.callCount).equals(0)
+		})
 	})
 	o.spec("merge", function() {
 		o("transforms an array of streams to an array of values", function() {


### PR DESCRIPTION
Based on #1307 

Passing a non-stream value to combine or merge will result in uncaught
errors.  This is one way to resolve it without adding a lot more bloat.

I thought to pre-filter or loop through the streams when `combine` is called to validate them prior to calling `initDependency`, but that seems like it may be unnecessary overhead.  Happy to make adjustments based on feedback.

EDIT: This doesn't actually stop the loop - I think that may be due mount attempting to re-render?  I'm not sure if it would make sense to allow the dependency to initialize but keep it in an errored state instead, then? (i.e. validate the streams and only pass valid items to `initDependency`, then throw manually in the callback)