### PR TITLE
Rebase #900, reactivate m.trust test.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,6 @@ We welcome any and all contributions. This is a community-driven project. Althou
 
 1. Please try to adhere to the style guide. Most of it is checked by ESLint. ESLint is also set up to check for other common errors, such as undeclared variables and invalid `typeof` values.
 2. Please make sure there are no regressions with your patch. Please don't disable existing tests, and please don't send a PR with new, disabled tests.
-	- There is [one known failing test](https://github.com/lhorie/mithril.js/blob/015f1275631d79681a22fcd4ddfec4b5c0f5f6a6/test/mithril.trust.js#L44-55) currently (PR welcome).
 3. For any new features introduced, be sure to write new unit tests for it. Maximum coverage is what we want.
 4. Try to not leave any extra `TODO`s, `FIXME`s, etc. in your code. ESLint will nag at you until you fix whatever problem it is.
 	- Note that it's only a warning, not an error. It won't fail the CI tests, and there's a few outstanding ones inside Mithril right now.

--- a/mithril.js
+++ b/mithril.js
@@ -533,6 +533,7 @@
 			} else if (editable) {
 				// contenteditable nodes use `innerHTML` instead of `nodeValue`.
 				editable.innerHTML = data
+				nodes = [].slice.call(editable.childNodes)
 			} else {
 				// was a trusted string
 				if (nodes[0].nodeType === 1 || nodes.length > 1 ||

--- a/test/mithril.render.js
+++ b/test/mithril.render.js
@@ -1577,5 +1577,18 @@ describe("m.render()", function () {
 			// This works only if select value is set after its options exist.
 			expect(root.childNodes[0].value).to.equal("b")
 		})
+
+		it("caches children of editable on update", function () {
+			var root = document.createElement("span")
+			var t1 = m.trust("<h1>fo</h1>o")
+			var t2 = "foo"
+
+			m.render(root, m("span", {contenteditable: false}, t1))
+			m.render(root, m("span", {contenteditable: true}, t2))
+			m.render(root, m("span", {contenteditable: false}, t1))
+
+			expect(root.childNodes[0].innerHTML).to.equal(t1.valueOf())
+
+		})
 	})
 })

--- a/test/mithril.trust.js
+++ b/test/mithril.trust.js
@@ -41,8 +41,7 @@ describe("m.trust()", function () {
 			expect(root.childNodes[3].tagName).to.equal("I")
 		})
 
-		// TODO: m.trust's contents are having their tags stripped.
-		xit("works with mixed trusted content in td", function () {
+		it("works with mixed trusted content in td", function () {
 			var root = document.createElement("table")
 			root.appendChild(root = document.createElement("tr"))
 


### PR DESCRIPTION
This is a rebased version of #900 with a proper commit message.

Also, the `m.trust()` test that was excluded is actually working!

#900 will probably have to be closed manually.