### PR TITLE
Permit a Component.view function to return an array of VirtualElements

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -565,7 +565,7 @@ declare namespace Mithril {
 		*
 		* @see m.component
 		*/
-		view(ctrl?: T, ...args: any[]): VirtualElement;
+		view(ctrl?: T, ...args: any[]): VirtualElement | Array<VirtualElement>;
 	}
 
 	/**


### PR DESCRIPTION
It is permissible in mithril for an array of virtual elements to be returned in lieu of one VE wrapping an array of children. This PR makes this evident in the TS definition file.