### PR TITLE
[rewrite] queryString parse - Prevent undesired date parsing

### DIFF
--- a/querystring/parse.js
+++ b/querystring/parse.js
@@ -15,7 +15,7 @@ module.exports = function(string) {
 		if (value !== "" && !isNaN(number) || value === "NaN") value = number
 		else if (value === "true") value = true
 		else if (value === "false") value = false
-		else {
+		else if (value.charAt(0) !== "/") {
 			var date = new Date(value)
 			if (!isNaN(date.getTime())) value = date
 		}

--- a/querystring/tests/test-parseQueryString.js
+++ b/querystring/tests/test-parseQueryString.js
@@ -20,6 +20,10 @@ o.spec("parseQueryString", function() {
 		var data = parseQueryString("?%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23=%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23")
 		o(data).deepEquals({";:@&=+$,/?%#": ";:@&=+$,/?%#"})
 	})
+	o("handles escaped slashes followed by a number", function () {
+		var data = parseQueryString("?hello=%2Fen%2F1")
+		o(data.hello).equals("/en/1")
+	})
 	o("handles escaped square brackets", function() {
 		var data = parseQueryString("?a%5B%5D=b")
 		o(data).deepEquals({"a": ["b"]})


### PR DESCRIPTION
#### Case:
Route to:
```
/login?message=Please%20log%20in%20to%20view%20this%20page&previous=%2Fen%2Fedit%2F1
```
The route contains a form that will set the path to the `previous` attr on successful login.  (Maybe this is a weird pattern but it seemed like a good idea at the time).

#### Result:
```
TypeError: path.indexOf is not a function(…)
```

#### Cause:

Native Date parsing is unpredictable and will occasionally turn a string
like "/foo/1" into a valid date of Jan 1, 2001.  This can be prevented
by not parsing a string that begins with a slash.

It's likely that this is a rare case, but it's annoying when it does
come up.

I wonder if there might be another issue hidden in here though - I'm not really sure why the path wouldn't be a string and therefore throw that type error.