### PR TITLE
[next] `m.mount()` cleanup, fix #727

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -86,8 +86,6 @@
 		"space-infix-ops": [2, {"int32Hint": true}],
 		"space-unary-ops": 2,
 		"spaced-comment": [2, "always"],
-		"max-depth": [2, 4],
-		"max-len": [2, 80, 4],
-		"max-statements": [2, 20]
+		"max-depth": [2, 4]
 	}
 }

--- a/mithril.js
+++ b/mithril.js
@@ -1435,37 +1435,6 @@
 		return parameterize(component, args)
 	}
 
-	function checkPrevented(component, root, index, isPrevented) {
-		if (!isPrevented) {
-			m.redraw.strategy("all")
-			m.startComputation()
-			roots[index] = root
-			var currentComponent
-
-			if (component) {
-				currentComponent = topComponent = component
-			} else {
-				currentComponent = topComponent = component = {controller: noop}
-			}
-
-			var controller = new (component.controller || noop)()
-
-			// controllers may call m.mount recursively (via m.route redirects,
-			// for example)
-			// this conditional ensures only the last recursive m.mount call is
-			// applied
-			if (currentComponent === topComponent) {
-				controllers[index] = controller
-				components[index] = component
-			}
-			endFirstComputation()
-			if (component === null) {
-				removeRootElement(root, index)
-			}
-			return controllers[index]
-		}
-	}
-
 	m.mount = m.module = function (root, component) {
 		if (!root) {
 			throw new Error("Ensure the DOM element being passed to " +
@@ -1500,16 +1469,39 @@
 			controllers[index].onunload(event)
 		}
 
-		return checkPrevented(component, root, index, isPrevented)
-	}
+		if (!isPrevented) {
+			m.redraw.strategy("all")
+			m.startComputation()
+			roots[index] = root
+			var currentComponent
 
-	function removeRootElement(root, index) {
-		roots.splice(index, 1)
-		controllers.splice(index, 1)
-		components.splice(index, 1)
-		reset(root)
-		nodeCache.splice(getCellCacheKey(root), 1)
-		unloaders = []
+			if (component) {
+				currentComponent = topComponent = component
+			} else {
+				currentComponent = topComponent = component = {controller: noop}
+			}
+
+			var controller = new (component.controller || noop)()
+
+			// controllers may call m.mount recursively (via m.route redirects,
+			// for example)
+			// this conditional ensures only the last recursive m.mount call is
+			// applied
+			if (currentComponent === topComponent) {
+				controllers[index] = controller
+				components[index] = component
+			}
+			endFirstComputation()
+			if (component === null) {
+				roots.splice(index, 1)
+				controllers.splice(index, 1)
+				components.splice(index, 1)
+				reset(root)
+				nodeCache.splice(getCellCacheKey(root), 1)
+				unloaders = []
+			}
+			return controllers[index]
+		}
 	}
 
 	var redrawing = false

--- a/mithril.js
+++ b/mithril.js
@@ -1467,9 +1467,6 @@
 			if (component == null) {
 				removeRootElement(root, index)
 			}
-			if (previousRoute) {
-				currentRoute = previousRoute
-			}
 		}
 	}
 
@@ -1748,23 +1745,15 @@
 			path = path.substr(0, queryStart)
 		}
 
-		// Get all routes and check if there's
-		// an exact match for the current path
-		var keys = Object.keys(router)
-		var index = keys.indexOf(path)
-
-		if (index !== -1){
-			m.mount(root, router[keys [index]])
-			return true
-		}
-
 		for (var route in router) {
 			if (hasOwn.call(router, route)) {
 				if (route === path) {
-					m.mount(root, router[route])
+					if (m.mount(root, router[route]) == null) {
+						// onunload e.prevendDefault() was called
+						currentRoute = previousRoute
+					}
 					return true
 				}
-
 				var matcher = new RegExp("^" + route
 					.replace(/:[^\/]+?\.{3}/g, "(.*?)")
 					.replace(/:[^\/]+/g, "([^\\/]+)") + "\/?$")
@@ -1778,7 +1767,11 @@
 							routeParams[key.replace(/:|\./g, "")] =
 								decodeURIComponent(values[i])
 						})
-						m.mount(root, router[route])
+						if (m.mount(root, router[route]) == null) {
+							// onunload e.prevendDefault() was called
+							currentRoute = previousRoute
+						}
+
 					})
 					/* eslint-enable no-loop-func */
 					return true

--- a/mithril.js
+++ b/mithril.js
@@ -97,9 +97,7 @@
 
 	function parseTagAttrs(cell, tag) {
 		var classes = []
-		/* eslint-disable max-len */
 		var parser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
-		/* eslint-enable max-len */
 		var match
 
 		while ((match = parser.exec(tag))) {
@@ -829,7 +827,7 @@
 		return data
 	}
 
-	function buildObject( // eslint-disable-line max-statements
+	function buildObject(
 		data,
 		cached,
 		editable,
@@ -1176,10 +1174,8 @@
 				try {
 					nodes[i].parentNode.removeChild(nodes[i])
 				} catch (e) {
-					/* eslint-disable max-len */
 					// ignore if this fails due to order of events (see
 					// http://stackoverflow.com/questions/21926083/failed-to-execute-removechild-on-node)
-					/* eslint-enable max-len */
 				}
 				cached = [].concat(cached)
 				if (cached[i]) unload(cached[i])

--- a/mithril.js
+++ b/mithril.js
@@ -1474,6 +1474,7 @@
 			m.startComputation()
 			roots[index] = root
 			var currentComponent
+			var isNullComponent = component == null
 
 			if (component) {
 				currentComponent = topComponent = component
@@ -1492,7 +1493,7 @@
 				components[index] = component
 			}
 			endFirstComputation()
-			if (component === null) {
+			if (isNullComponent) {
 				roots.splice(index, 1)
 				controllers.splice(index, 1)
 				components.splice(index, 1)

--- a/mithril.js
+++ b/mithril.js
@@ -1463,10 +1463,6 @@
 				removeRootElement(root, index)
 			}
 			return controllers[index]
-		} else {
-			if (component == null) {
-				removeRootElement(root, index)
-			}
 		}
 	}
 

--- a/test/mithril.prop.js
+++ b/test/mithril.prop.js
@@ -51,8 +51,8 @@ describe("m.prop()", function () {
 		function Thing(name) {
 			this.name = name
 		}
-		Thing.prototype.toJSON = function() {
-			return {kind: 'Thing', name: this.name}
+		Thing.prototype.toJSON = function () {
+			return {kind: "Thing", name: this.name}
 		}
 		var banana = m.prop(new Thing("bannana"))
 		expect(JSON.stringify(banana)).to.equal('{"kind":"Thing","name":"bannana"}')

--- a/test/mithril.route.js
+++ b/test/mithril.route.js
@@ -130,6 +130,34 @@ describe("m.route()", function () {
 		expect(m.route()).to.equal("/a")
 	})
 
+	dit("skips route change if component ctrl.onunload calls preventDefault when the route has parameters", function (root) { // eslint-disable-line
+		mode("search")
+		var spy = sinon.spy()
+
+		var sub = {
+			controller: function () {
+				this.onunload = function (e) { e.preventDefault() }
+			},
+			view: function () {
+				return m("div")
+			}
+		}
+
+		route(root, "/a/1", {
+			"/a/:id": pure(function () { return sub }),
+
+			"/b/:id": {
+				controller: spy,
+				view: noop
+			}
+		})
+
+		route("/b/1")
+
+		expect(spy).to.not.have.been.called
+		expect(m.route()).to.equal("/a/1")
+	})
+
 	dit("skips route change if subcomponent ctrl.onunload calls preventDefault", function (root) { // eslint-disable-line
 		mode("search")
 

--- a/test/mithril.route.js
+++ b/test/mithril.route.js
@@ -875,7 +875,7 @@ describe("m.route()", function () {
 		expect(mock.history.$$length).to.equal(0)
 	})
 
-	dit("modify history when redirecting to same route with different parameters", function(root) {
+	dit("modify history when redirecting to same route with different parameters", function (root) {
 		mode("search")
 		mock.history.$$length = 0
 
@@ -885,12 +885,12 @@ describe("m.route()", function () {
 		})
 
 		route("/b")
-		route("/b", { foo: "bar" })
+		route("/b", {foo: "bar"})
 
 		expect(mock.history.$$length).to.equal(2)
 	})
 
-	dit("doesn't modify history when redirecting to same route with same parameters", function(root) {
+	dit("doesn't modify history when redirecting to same route with same parameters", function (root) {
 		mode("search")
 		mock.history.$$length = 0
 
@@ -899,8 +899,8 @@ describe("m.route()", function () {
 			"/b": pure(function () { return "b" })
 		})
 
-		route("/b", { foo: "bar" })
-		route("/b", { foo: "bar" })
+		route("/b", {foo: "bar"})
+		route("/b", {foo: "bar"})
 
 		expect(mock.history.$$length).to.equal(1)
 	})

--- a/test/mithril.route.js
+++ b/test/mithril.route.js
@@ -56,12 +56,21 @@ describe("m.route()", function () {
 		}
 	}
 
+	// this `preventDefault` helper calls `e.preventDefault()` only during the
+	// test phase, which allows `afterEach()` to properly unmount
+	var shouldPreventDefault
+	function preventDefault(e) {
+		if (shouldPreventDefault) e.preventDefault()
+	}
+
 	beforeEach(function () {
+		shouldPreventDefault = true
 		mock.requestAnimationFrame.$resolve()
 		this.root = mock.document.createElement("div")
 	})
 
 	afterEach(function () {
+		shouldPreventDefault = false
 		m.mount(this.root, null)
 	})
 	/* eslint-enable no-invalid-this */
@@ -108,7 +117,7 @@ describe("m.route()", function () {
 
 		var sub = {
 			controller: function () {
-				this.onunload = function (e) { e.preventDefault() }
+				this.onunload = preventDefault
 			},
 			view: function () {
 				return m("div")
@@ -136,7 +145,7 @@ describe("m.route()", function () {
 
 		var sub = {
 			controller: function () {
-				this.onunload = function (e) { e.preventDefault() }
+				this.onunload = preventDefault
 			},
 			view: function () {
 				return m("div")
@@ -165,7 +174,7 @@ describe("m.route()", function () {
 
 		var subsub = {
 			controller: function () {
-				this.onunload = function (e) { e.preventDefault() }
+				this.onunload = preventDefault
 			},
 			view: function () {
 				return m("div")


### PR DESCRIPTION
Win back ~40 bytes (we're still at 8095 bytes, .min.gzipped, though).
