### PR TITLE
[rewrite] respect keys on routed components.

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -8,7 +8,7 @@ module.exports = function($window, mount) {
 	var currentResolve, currentComponent, currentRender, currentArgs, currentPath
 
 	var RouteComponent = {view: function() {
-		return currentRender(Vnode(currentComponent, null, currentArgs, undefined, undefined, undefined))
+		return [currentRender(Vnode(currentComponent, null, currentArgs, undefined, undefined, undefined))]
 	}}
 	function defaultRender(vnode) {
 		return vnode

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -293,6 +293,32 @@ o.spec("route", function() {
 					o(root.firstChild.nodeName).equals("DIV")
 				})
 
+				o("changing `vnode.key` in `render` resets the component", function(done, timeout){
+					timeout(FRAME_BUDGET * 3)
+
+					var oninit = o.spy()
+					var Component = {
+						oninit: oninit,
+						view: function(){
+							return m("div")
+						}
+					}
+					$window.location.href = prefix + "/abc"
+					route(root, "/abc", {
+						"/:id": {render: function(vnode) {
+							return m(Component, {key: vnode.attrs.id})
+						}}
+					})
+					setTimeout(function(){
+						o(oninit.callCount).equals(1)
+						route.set('/def')
+						setTimeout(function(){
+							o(oninit.callCount).equals(2)
+							done()
+						}, FRAME_BUDGET)
+					}, FRAME_BUDGET)
+				})
+
 				o("accepts RouteResolver without `onmatch` method as payload", function() {
 					var renderCount = 0
 					var Component = {


### PR DESCRIPTION
Currently, changing the `key` on the `vnode` of a routed component doesn't have any effect. This prevents the re-initialization of components in user-defined circumstances.

