### PR TITLE
[rewrite] Auto apply browser mock if not in browser environment - fixes #1279

### DIFF
--- a/render.js
+++ b/render.js
@@ -1,1 +1,3 @@
+var window = require("./window")
+
 module.exports = require("./render/render")(window)

--- a/request.js
+++ b/request.js
@@ -1,2 +1,4 @@
 var Stream = require("./stream")
+var window = require("./window")
+
 module.exports = require("./request/request")(window, Stream)

--- a/route.js
+++ b/route.js
@@ -1,3 +1,4 @@
 var mount = require("./mount")
+var window = require("./window")
 
 module.exports = require("./api/router")(window, mount)

--- a/window.js
+++ b/window.js
@@ -1,0 +1,1 @@
+module.exports = typeof window === "undefined" ? require("./test-utils/browserMock")() : window


### PR DESCRIPTION
This solves the issue with undefined `window` when using mithril in node. It uses the mock in case there is no global `window` available.

Don't know if this is too much magic though.
