### PR TITLE
[rewrite] Support classes and factory components

### DIFF
--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -5,7 +5,7 @@ var Vnode = require("../render/vnode")
 var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
 var selectorCache = {}
 function hyperscript(selector) {
-	if (selector == null || typeof selector !== "string" && selector.view == null) {
+	if (selector == null || typeof selector !== "string" && typeof selector !== "function" && selector.view == null) {
 		throw Error("The selector must be either a string or a component.");
 	}
 

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -764,7 +764,7 @@ o.spec("component", function() {
 		})
 		o("Factory functions can be used as components", function() {
 			var state, context
-			function component() {}
+			function component() {
 				return state = {
 					oninit: o.spy(function(vnode) {
 						o(this).equals(vnode.state)

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -696,12 +696,16 @@ o.spec("component", function() {
 				o(vnode.state.data[0]).equals(body)
 			}
 		})
-		o("Classes can be sued as components", function() {
-			var proto = new Component()
+	})
+	o.spec("Alternative ways to specify componenents", function() {
+		o("Classes can be used as components", function() {
+			function MyComponent(){}
+			var proto = MyComponent.prototype = new Component()
 			
-			var state, context
+			var context
 
 			proto.oninit = o.spy(function(vnode) {
+				o(this).equals(vnode.state)
 				context = this
 			})
 			proto.oncreate = o.spy()
@@ -712,11 +716,10 @@ o.spec("component", function() {
 			proto.view = o.spy(function() {
 				return ""
 			})
-			
-			function MyComponent(){}
-			MyComponent.prototype = proto
 
 			render(root, [{tag: MyComponent}])
+
+			o(context instanceof MyComponent).equals(true)
 
 			o(proto.view.callCount).equals(1)
 			o(proto.oncreate.callCount).equals(1)
@@ -758,6 +761,73 @@ o.spec("component", function() {
 			o(proto.onupdate.args.length).equals(1)
 			o(proto.onbeforeremove.args.length).equals(2)
 			o(proto.onremove.args.length).equals(1)
+		})
+		o("Factory functions can be used as components", function() {
+			var state, context
+			function component() {}
+				return state = {
+					oninit: o.spy(function(vnode) {
+						o(this).equals(vnode.state)
+						context = this
+					}),
+					oncreate: o.spy(),
+					onbeforeupdate: o.spy(),
+					onupdate: o.spy(),
+					onbeforeremove: o.spy(function(vnode, done) {done()}),
+					onremove: o.spy(),
+					view: o.spy(function() {
+						return ""
+					})
+				}
+			}
+
+			render(root, [{tag: component}])
+
+			o(state).equals(context)
+
+			o(state.oninit.callCount).equals(1)
+			o(state.view.callCount).equals(1)
+			o(state.oncreate.callCount).equals(1)
+			o(state.onbeforeupdate.callCount).equals(0)
+			o(state.onupdate.callCount).equals(0)
+			o(state.onbeforeremove.callCount).equals(0)
+			o(state.onremove.callCount).equals(0)
+
+			render(root, [{tag: component}])
+
+			o(state.oninit.callCount).equals(1)
+			o(state.view.callCount).equals(2)
+			o(state.oncreate.callCount).equals(1)
+			o(state.onbeforeupdate.callCount).equals(1)
+			o(state.onupdate.callCount).equals(1)
+			o(state.onbeforeremove.callCount).equals(0)
+			o(state.onremove.callCount).equals(0)
+
+			render(root, [])
+
+			o(state.oninit.callCount).equals(1)
+			o(state.view.callCount).equals(2)
+			o(state.oncreate.callCount).equals(1)
+			o(state.onbeforeupdate.callCount).equals(1)
+			o(state.onupdate.callCount).equals(1)
+			o(state.onbeforeremove.callCount).equals(1)
+			o(state.onremove.callCount).equals(1)
+
+			o(component.oninit.this).equals(context)
+			o(state.view.this).equals(state)
+			o(state.oncreate.this).equals(state)
+			o(state.onbeforeupdate.this).equals(state)
+			o(state.onupdate.this).equals(state)
+			o(state.onbeforeremove.this).equals(state)
+			o(state.onremove.this).equals(state)
+
+			o(state.oninit.args.length).equals(1)
+			o(state.view.args.length).equals(1)
+			o(state.oncreate.args.length).equals(1)
+			o(state.onbeforeupdate.args.length).equals(2)
+			o(state.onupdate.args.length).equals(1)
+			o(state.onbeforeremove.args.length).equals(2)
+			o(state.onremove.args.length).equals(1)
 		})
 	})
 })

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -5,11 +5,14 @@ var domMock = require("../../test-utils/domMock")
 var vdom = require("../../render/render")
 
 o.spec("component", function() {
-	var $window, root, render
+	var $window, root, renderer, render, Component
 	o.beforeEach(function() {
 		$window = domMock()
 		root = $window.document.createElement("div")
-		render = vdom($window).render
+		
+		renderer = vdom($window)
+		render = renderer.render
+		Component = renderer.Component
 	})
 
 	o.spec("basics", function() {
@@ -693,73 +696,68 @@ o.spec("component", function() {
 				o(vnode.state.data[0]).equals(body)
 			}
 		})
-		o("the view and hooks are looked up on the state object", function() {
-			var state = {
-				oncreate: o.spy(),
-				onbeforeupdate: o.spy(),
-				onupdate: o.spy(),
-				onbeforeremove: o.spy(function(vnode, done) {done()}),
-				onremove: o.spy(),
-				view: o.spy()
-			}
-			var context
-			var component = {
-				oninit: o.spy(function(vnode) {
-					context = this
-					vnode.state = state
-				}),
-				view: o.spy(function() {
-					return ""
-				})
-			}
-			render(root, [{tag: component}])
+		o("Classes can be sued as components", function() {
+			var proto = new Component()
+			
+			var state, context
 
-			o(component.oninit.callCount).equals(1)
-			o(component.view.callCount).equals(0)
-			o(state.view.callCount).equals(1)
-			o(state.oncreate.callCount).equals(1)
-			o(state.onbeforeupdate.callCount).equals(0)
-			o(state.onupdate.callCount).equals(0)
-			o(state.onbeforeremove.callCount).equals(0)
-			o(state.onremove.callCount).equals(0)
+			proto.oninit = o.spy(function(vnode) {
+				context = this
+			})
+			proto.oncreate = o.spy()
+			proto.onbeforeupdate = o.spy()
+			proto.onupdate = o.spy()
+			proto.onbeforeremove = o.spy(function(vnode, done) {done()})
+			proto.onremove = o.spy()
+			proto.view = o.spy(function() {
+				return ""
+			})
+			
+			function MyComponent(){}
+			MyComponent.prototype = proto
 
-			render(root, [{tag: component}])
+			render(root, [{tag: MyComponent}])
 
-			o(component.oninit.callCount).equals(1)
-			o(component.view.callCount).equals(0)
-			o(state.view.callCount).equals(2)
-			o(state.oncreate.callCount).equals(1)
-			o(state.onbeforeupdate.callCount).equals(1)
-			o(state.onupdate.callCount).equals(1)
-			o(state.onbeforeremove.callCount).equals(0)
-			o(state.onremove.callCount).equals(0)
+			o(proto.view.callCount).equals(1)
+			o(proto.oncreate.callCount).equals(1)
+			o(proto.onbeforeupdate.callCount).equals(0)
+			o(proto.onupdate.callCount).equals(0)
+			o(proto.onbeforeremove.callCount).equals(0)
+			o(proto.onremove.callCount).equals(0)
+
+			render(root, [{tag: MyComponent}])
+
+			o(proto.view.callCount).equals(2)
+			o(proto.oncreate.callCount).equals(1)
+			o(proto.onbeforeupdate.callCount).equals(1)
+			o(proto.onupdate.callCount).equals(1)
+			o(proto.onbeforeremove.callCount).equals(0)
+			o(proto.onremove.callCount).equals(0)
 
 			render(root, [])
 
-			o(component.oninit.callCount).equals(1)
-			o(component.view.callCount).equals(0)
-			o(state.view.callCount).equals(2)
-			o(state.oncreate.callCount).equals(1)
-			o(state.onbeforeupdate.callCount).equals(1)
-			o(state.onupdate.callCount).equals(1)
-			o(state.onbeforeremove.callCount).equals(1)
-			o(state.onremove.callCount).equals(1)
+			o(proto.view.callCount).equals(2)
+			o(proto.oncreate.callCount).equals(1)
+			o(proto.onbeforeupdate.callCount).equals(1)
+			o(proto.onupdate.callCount).equals(1)
+			o(proto.onbeforeremove.callCount).equals(1)
+			o(proto.onremove.callCount).equals(1)
 
-			o(component.oninit.this).equals(context)
-			o(state.view.this).equals(state)
-			o(state.oncreate.this).equals(state)
-			o(state.onbeforeupdate.this).equals(state)
-			o(state.onupdate.this).equals(state)
-			o(state.onbeforeremove.this).equals(state)
-			o(state.onremove.this).equals(state)
+			o(proto.oninit.this).equals(context)
+			o(proto.view.this).equals(context)
+			o(proto.oncreate.this).equals(context)
+			o(proto.onbeforeupdate.this).equals(context)
+			o(proto.onupdate.this).equals(context)
+			o(proto.onbeforeremove.this).equals(context)
+			o(proto.onremove.this).equals(context)
 
-			o(component.oninit.args.length).equals(1)
-			o(state.view.args.length).equals(1)
-			o(state.oncreate.args.length).equals(1)
-			o(state.onbeforeupdate.args.length).equals(2)
-			o(state.onupdate.args.length).equals(1)
-			o(state.onbeforeremove.args.length).equals(2)
-			o(state.onremove.args.length).equals(1)
+			o(proto.oninit.args.length).equals(1)
+			o(proto.view.args.length).equals(1)
+			o(proto.oncreate.args.length).equals(1)
+			o(proto.onbeforeupdate.args.length).equals(2)
+			o(proto.onupdate.args.length).equals(1)
+			o(proto.onbeforeremove.args.length).equals(2)
+			o(proto.onremove.args.length).equals(1)
 		})
 	})
 })

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -693,5 +693,73 @@ o.spec("component", function() {
 				o(vnode.state.data[0]).equals(body)
 			}
 		})
+		o("the view and hooks are looked up on the state object", function() {
+			var state = {
+				oncreate: o.spy(),
+				onbeforeupdate: o.spy(),
+				onupdate: o.spy(),
+				onbeforeremove: o.spy(function(vnode, done) {done()}),
+				onremove: o.spy(),
+				view: o.spy()
+			}
+			var context
+			var component = {
+				oninit: o.spy(function(vnode) {
+					context = this
+					vnode.state = state
+				}),
+				view: o.spy(function() {
+					return ""
+				})
+			}
+			render(root, [{tag: component}])
+
+			o(component.oninit.callCount).equals(1)
+			o(component.view.callCount).equals(0)
+			o(state.view.callCount).equals(1)
+			o(state.oncreate.callCount).equals(1)
+			o(state.onbeforeupdate.callCount).equals(0)
+			o(state.onupdate.callCount).equals(0)
+			o(state.onbeforeremove.callCount).equals(0)
+			o(state.onremove.callCount).equals(0)
+
+			render(root, [{tag: component}])
+
+			o(component.oninit.callCount).equals(1)
+			o(component.view.callCount).equals(0)
+			o(state.view.callCount).equals(2)
+			o(state.oncreate.callCount).equals(1)
+			o(state.onbeforeupdate.callCount).equals(1)
+			o(state.onupdate.callCount).equals(1)
+			o(state.onbeforeremove.callCount).equals(0)
+			o(state.onremove.callCount).equals(0)
+
+			render(root, [])
+
+			o(component.oninit.callCount).equals(1)
+			o(component.view.callCount).equals(0)
+			o(state.view.callCount).equals(2)
+			o(state.oncreate.callCount).equals(1)
+			o(state.onbeforeupdate.callCount).equals(1)
+			o(state.onupdate.callCount).equals(1)
+			o(state.onbeforeremove.callCount).equals(1)
+			o(state.onremove.callCount).equals(1)
+
+			o(component.oninit.this).equals(context)
+			o(state.view.this).equals(state)
+			o(state.oncreate.this).equals(state)
+			o(state.onbeforeupdate.this).equals(state)
+			o(state.onupdate.this).equals(state)
+			o(state.onbeforeremove.this).equals(state)
+			o(state.onremove.this).equals(state)
+
+			o(component.oninit.args.length).equals(1)
+			o(state.view.args.length).equals(1)
+			o(state.oncreate.args.length).equals(1)
+			o(state.onbeforeupdate.args.length).equals(2)
+			o(state.onupdate.args.length).equals(1)
+			o(state.onbeforeremove.args.length).equals(2)
+			o(state.onremove.args.length).equals(1)
+		})
 	})
 })

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -427,8 +427,7 @@ o.spec("hyperscript", function() {
 			o(vnode.children[0].tag).equals("#")
 			o(vnode.children[0].children).equals("b")
 		})
-	})
-	o("works with functions", function() {
+		o("works with functions", function() {
 			var component = o.spy()
 			
 			var vnode = m(component, {id: "a"}, "b")

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -433,7 +433,7 @@ o.spec("hyperscript", function() {
 			
 			var vnode = m(component, {id: "a"}, "b")
 
-			o(component.callcount)equals(0)
+			o(component.callcount).equals(0)
 			
 			o(vnode.tag).equals(component)
 			o(vnode.attrs.id).equals("a")

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -413,7 +413,7 @@ o.spec("hyperscript", function() {
 		})
 	})
 	o.spec("components", function() {
-		o("works", function() {
+		o("works with POJOs", function() {
 			var component = {
 				view: function() {
 					return m("div")
@@ -421,6 +421,20 @@ o.spec("hyperscript", function() {
 			}
 			var vnode = m(component, {id: "a"}, "b")
 
+			o(vnode.tag).equals(component)
+			o(vnode.attrs.id).equals("a")
+			o(vnode.children.length).equals(1)
+			o(vnode.children[0].tag).equals("#")
+			o(vnode.children[0].children).equals("b")
+		})
+	})
+	o("works with functions", function() {
+			var component = o.spy()
+			
+			var vnode = m(component, {id: "a"}, "b")
+
+			o(component.callcount)equals(0)
+			
 			o(vnode.tag).equals(component)
 			o(vnode.attrs.id).equals("a")
 			o(vnode.children.length).equals(1)


### PR DESCRIPTION
*Caveat emptor*, this was all written in the github web interface without any test, CI will tell us if there are any issues.

Barring syntax errors and other superficial issues, this should enable classes and factories as components. The changes are minimal.

A few things are still missing:

- docs
- expose `renderer.Component` as `m.Component` (doing so from this branch would result in a merge conflict)

fingers crossed...

Edit: syntax error, I'll fix it later today.