### PR TITLE
[rewrite:ospec] Adjust ospec bin def, add to README

### DIFF
--- a/ospec/README.md
+++ b/ospec/README.md
@@ -4,7 +4,7 @@
 
 Noiseless testing framework
 
-Version: 1.1 
+Version: 1.1
 License: MIT
 
 ## About
@@ -257,6 +257,42 @@ _o("a test", function() {
 	_o(1).equals(1)
 })
 _o.run()
+```
+
+### Running the test suite from the command-line
+
+ospec will automatically evaluate all `*.js` files in any folder named `/tests`.
+
+`o.run()` is automatically called by the cli - no need to call it in your test code.
+
+#### Create an npm script in your package:
+```
+	"scripts": {
+		...
+		"test": "ospec",
+		...
+	}
+```
+
+```
+	$ npm test
+```
+
+#### (Optionally) Install Globally
+
+```
+	$ npm i -g ospec
+	$ ospec
+```
+
+#### (Optionally) Evaluate ES6+ code:
+
+One way to accomplish this would be to include the 'babel-cli' module (`npm i babel-cli`)
+
+(This would pre-suppose that you're already using babel in your project and thus have it configured to your liking).
+
+```
+	$ babel-node ospec
 ```
 
 ---

--- a/ospec/package.json
+++ b/ospec/package.json
@@ -9,6 +9,8 @@
   "keywords": [ "testing" ],
   "author": "Leo Horie <lhorie@hotmail.com>",
   "license": "MIT",
-  "bin": "./bin/ospec",
+  "bin": {
+    "ospec": "./bin/ospec"
+  },
   "repository": "lhorie/mithril.js#rewrite"
 }


### PR DESCRIPTION
Getting set up with ospec is deceptively simple, and adding just a bit
more documentation should help new users from falling into the trap of
overthinking the test config.  I know that I ended up down a very
strange rabbit hole when pulling ospec into a small project -- 
trying to use rollup and all kinds of goofy things on my test files. 😅

This also adjusts the bin definition in the package file so that we can
hopefully just use the `ospec` command instead of a folder ref.

---

I know that the current bin definition *should* work, but the `ospec` command doesn't seem to work for me when installing to other projects so I'm trying to see if explicitly declaring the name will help to fix that.