### PR TITLE
[rewrite] Ignore modifier+click and middle click in m.route.link

### DIFF
--- a/router/router.js
+++ b/router/router.js
@@ -112,6 +112,7 @@ module.exports = function($window) {
 	function link(vnode) {
 		vnode.dom.setAttribute("href", prefix + vnode.attrs.href)
 		vnode.dom.onclick = function(e) {
+			if (e.ctrlKey || e.metaKey || e.shiftKey || e.which === 2) return
 			e.preventDefault()
 			e.redraw = false
 			var href = this.getAttribute("href")


### PR DESCRIPTION
Currently, middle clicking and ctrl+click change the route in the current tab. Expected behavior is to open a new tab/window. This line was pulled verbatim from v0.2.5. Was the absence of this feature of an oversight?