### PR TITLE
upgrade doc: rename ctrl to state

### DIFF
--- a/docs/v1.x-migration.md
+++ b/docs/v1.x-migration.md
@@ -134,15 +134,15 @@ m.mount(document.body, {
 
 m.mount(document.body, {
     oninit : function(vnode) {
-        var ctrl = this;  // this is bound to vnode.state by default
+        var state = this;  // this is bound to vnode.state by default
 
-        ctrl.fooga = 1;
+        state.fooga = 1;
     },
 
     view : function(vnode) {
-        var ctrl = this; // this is bound to vnode.state by default
+        var state = this; // this is bound to vnode.state by default
 
-        return m("p", ctrl.fooga);
+        return m("p", state.fooga);
     }
 });
 ```


### PR DESCRIPTION
I am not sure you agree, but i find the name `state` a bit less confusing that the name `ctrl` used in v.0.2.x. At 1st sight i asked myself "what controller?", right after I read there was no `controller` function anymore.
thank you and kind regards