### PR TITLE
remove unneeded else

### DIFF
--- a/render/vnode.js
+++ b/render/vnode.js
@@ -3,7 +3,7 @@ function Vnode(tag, key, attrs, children, text, dom) {
 }
 Vnode.normalize = function(node) {
 	if (node instanceof Array) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)
-	else if (node != null && typeof node !== "object") return Vnode("#", undefined, undefined, node, undefined, undefined)
+	if (node != null && typeof node !== "object") return Vnode("#", undefined, undefined, node, undefined, undefined)
 	return node
 }
 Vnode.normalizeChildren = function normalizeChildren(children) {


### PR DESCRIPTION
Hello @lhorie,

maybe this can be thought more as a style habit. I always rewrite conditions that only return values like this:

```js
// pseudo-code
function getSomething() {
    if (cond1) {
        // do something
        return value1;
    } else if (cond2) {
        // do something
        return value2;
    } else if (cond3) {
        // do something
        return value3;
    } else {
        return default;
    }
}
``` 

to

```js
// pseudo-code
function getSomething() {
    if (cond1) {
        // do something
        return value1;
    } 

    if (cond2) {
        // do something
        return value2;
    }

    if (cond3) {
        // do something
        return value3;
    }

    return default;
}
``` 

and of course with 1 line condition/expression pairs they look like shorter version of switch() with the benefit of the availability of strict type checking in conditions.

```js
// pseudo-code
function getSomething() {
    if (cond1) return expression1;
    if (cond2) return expression2;
    if (cond3) return expression3;

    return default;
}
``` 

kind regards