### PR TITLE
'catch' is a reserved word in IE 8 / 9

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1852,7 +1852,7 @@
 			return propify(promise.then(resolve, reject), initialValue)
 		}
 
-		prop.catch = prop.then.bind(null, null)
+		prop["catch"] = prop.then.bind(null, null)
 		return prop
 	}
 	// Promiz.mithril.js | Zolmeister | MIT


### PR DESCRIPTION
By using 'catch' word that is reserved word in JavaScript, Syntax Error is occured in IE 8 / 9 with parsing mithril code.

To fix it, enclose 'catch' word with [].

Thanks. 

 