### PR TITLE
Add failing test and proposed fix for SVG update with tag change.

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -213,7 +213,7 @@ module.exports = function($window) {
 		}
 		else {
 			removeNode(old, null)
-			insertNode(parent, createNode(vnode, hooks, undefined), nextSibling)
+			insertNode(parent, createNode(vnode, hooks, ns), nextSibling)
 		}
 	}
 	function updateText(old, vnode) {

--- a/render/tests/test-updateElement.js
+++ b/render/tests/test-updateElement.js
@@ -211,6 +211,19 @@ o.spec("updateElement", function() {
 
 		o(updated.dom.attributes["class"].nodeValue).equals("b")
 	})
+	o("updates svg child", function() {
+		var vnode = {tag: "svg", children: [{
+			tag: 'circle'
+		}]}
+		var updated = {tag: "svg", children: [{
+			tag: 'line'
+		}]}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		o(updated.dom.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
+	})
 	o("restores correctly when recycling", function() {
 		var vnode = {tag: "div", key: 1}
 		var updated = {tag: "div", key: 2}


### PR DESCRIPTION
When updating an SVG element and changing its tag, the namespace is lost and the element becomes unknown HTML. See new test case.

Thanks for mithril!

Thibault @ lichess.org