### PR TITLE
[rewrite] handle fragmented attrs and children

### DIFF
--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -52,18 +52,23 @@ function hyperscript(selector) {
 		}
 	}
 
-	var attrs = {}, children = []
-	function processArgument(arg) {
-		if (arg == null || typeof arg === "object" && arg.tag === undefined && !isArray(arg)) {
+	var args = Array.prototype.slice.call(arguments),
+		attrs = {}, children = [], childrenIndex = 0
+	args.forEach(function(arg, index) {
+		if (!index) return
+		if (!childrenIndex && (arg == null || typeof arg === "object" && arg.tag === undefined && !isArray(arg))) {
 			Object.keys(arg || {}).forEach(function(key) {
 				attrs[key] = arg[key]
 			})
 		} else {
-			if (isArray(arg)) children = children.concat(arg)
-				else children.push(arg)
+			childrenIndex = childrenIndex ? childrenIndex : index
+			if (index === childrenIndex && args.length === childrenIndex + 1 && isArray(arg)) {
+				children = children.concat(arg)
+			} else {
+				children.push(arg)
+			}
 		}
-	}
-	for (var i = 1; i < arguments.length; i++) processArgument(arguments[i])
+	})
 
 	if (typeof selector === "string") return selectorCache[selector](attrs, Vnode.normalizeChildren(children))
 

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -4,6 +4,11 @@ var Vnode = require("../render/vnode")
 
 var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
 var selectorCache = {}
+
+function isArray(obj) {
+	return obj instanceof Array
+}
+
 function hyperscript(selector) {
 	if (selector == null || typeof selector !== "string" && selector.view == null) {
 		throw Error("The selector must be either a string or a component.");
@@ -40,29 +45,29 @@ function hyperscript(selector) {
 					break
 				}
 			}
-			if (children instanceof Array && children.length == 1 && children[0] != null && children[0].tag === "#") text = children[0].children
+			if (isArray(children) && children.length == 1 && children[0] != null && children[0].tag === "#") text = children[0].children
 			else childList = children
 
 			return Vnode(tag || "div", attrs.key, hasAttrs ? attrs : undefined, childList, text, undefined)
 		}
 	}
-	var attrs, children, childrenIndex
-	if (arguments[1] == null || typeof arguments[1] === "object" && arguments[1].tag === undefined && !(arguments[1] instanceof Array)) {
-		attrs = arguments[1]
-		childrenIndex = 2
-	}
-	else childrenIndex = 1
-	if (arguments.length === childrenIndex + 1) {
-		children = arguments[childrenIndex] instanceof Array ? arguments[childrenIndex] : [arguments[childrenIndex]]
-	}
-	else {
-		children = []
-		for (var i = childrenIndex; i < arguments.length; i++) children.push(arguments[i])
-	}
 
-	if (typeof selector === "string") return selectorCache[selector](attrs || {}, Vnode.normalizeChildren(children))
+	var attrs = {}, children = []
+	function processArgument(arg) {
+		if (arg == null || typeof arg === "object" && arg.tag === undefined && !isArray(arg)) {
+			Object.keys(arg || {}).forEach(function(key) {
+				attrs[key] = arg[key]
+			})
+		} else {
+			if (isArray(arg)) children = children.concat(arg)
+				else children.push(arg)
+		}
+	}
+	for (var i = 1; i < arguments.length; i++) processArgument(arguments[i])
 
-	return Vnode(selector, attrs && attrs.key, attrs || {}, Vnode.normalizeChildren(children), undefined, undefined)
+	if (typeof selector === "string") return selectorCache[selector](attrs, Vnode.normalizeChildren(children))
+
+	return Vnode(selector, attrs && attrs.key, attrs, Vnode.normalizeChildren(children), undefined, undefined)
 }
 
 module.exports = hyperscript

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -179,6 +179,13 @@ o.spec("hyperscript", function() {
 			o(vnode.attrs.a).equals("b")
 			o(vnode.attrs.c).equals("d")
 		})
+		o("handle fragmented attrs", function() {
+			var vnode = m("div", {a: "b"}, {c: "d"})
+
+			o(vnode.tag).equals("div")
+			o(vnode.attrs.a).equals("b")
+			o(vnode.attrs.c).equals("d")
+		})
 		o("handles className attrs property", function() {
 			var vnode = m("div", {className: "a"})
 


### PR DESCRIPTION
Handle fragmented attributes so that there is no need for end-users to depend on merging libraries or polyfills.