### PR TITLE
Fix blinking select in chrome when setting select property in select tag

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -432,6 +432,8 @@ module.exports = function($window) {
 		else if (key in element && !isAttribute(key) && ns === undefined) {
 			//setting input[value] to same value by typing on focused element moves cursor to end in Chrome
 			if (vnode.tag === "input" && key === "value" && vnode.dom.value === value && vnode.dom === $doc.activeElement) return
+			//setting select[value] to same value while having select open blinks select dropdown in Chrome
+			if (vnode.tag === "select" && key === "value" && vnode.dom.value === value && vnode.dom === $doc.activeElement) return
 			//setting option[value] to same value while having select open blinks select dropdown in Chrome
 			if (vnode.tag === "option" && key === "value" && vnode.dom.value === value) return
 			element[key] = value


### PR DESCRIPTION
This fixes #1413 for a case that was not covered by #1415 , when setting `value` property of `select` tag directly as in here:

```js
m('select', { value: myvalue },  options.map(renderOption))
```

