### PR TITLE
Remove Grunt path dependency by aliasing core Grunt tasks to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "url" : "http://github.com/lhorie/mithril.js/issues"
   },
   "scripts": {
-  	"build": "grunt build",
-  	"lint": "grunt lint",
-  	"sauce": "grunt sauce",
+    "build": "grunt build",
+    "lint": "grunt lint",
+    "sauce": "grunt sauce",
     "test": "grunt test"
   },
   "main": "mithril.js",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "url" : "http://github.com/lhorie/mithril.js/issues"
   },
   "scripts": {
+  	"build": "grunt build",
+  	"lint": "grunt lint",
+  	"sauce": "grunt sauce",
     "test": "grunt test"
   },
   "main": "mithril.js",


### PR DESCRIPTION
This allows you to `npm run build` after `npm i` without having to globally install Grunt CLI.