### PR TITLE
Demystify component antipatterns

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -169,11 +169,11 @@ Be aware that when using ES5 functions, the value of `this` in nested anonymous 
 
 ### Avoid anti-patterns
 
-Although Mithril is flexible, some code patterns are discouraged:
+Try to keep component interfaces generic by default - use custom interfaces when implementation isn't generic.
 
-#### Avoid restrictive interfaces
+#### Avoiding restrictive interfaces
 
-A component has a restrictive interface when it exposes only specific properties, under the assumption that other properties will not be needed, or that they can be added at a later time.
+A component has a restrictive interface when it is unnecessarily specific in its use of attributes. Custom attributes should be used when a component has a very specific purpose or requires special internal logic, but this often isn't the case - attributes and children should be used where possible.
 
 In the example below, the `button` configuration is severely limited: it does not support any events other than `onclick`, it's not styleable and it only accepts text as children (but not elements, fragments or trusted HTML).
 
@@ -188,7 +188,7 @@ var RestrictiveComponent = {
 }
 ```
 
-It's preferable to allow passing through parameters to a component's root node, if it makes sense to do so:
+If the required attributes are equivalent to generic DOM attributes, it's preferable to allow passing through parameters to a component's root node, if it makes sense to do so.
 
 ```javascript
 // PREFER
@@ -201,7 +201,9 @@ var FlexibleComponent = {
 }
 ```
 
-#### Avoid magic indexes
+#### Don't manipulate `children`
+
+However, if a component is opinionated in how it applies attributes or children, you should switch to using custom attributes.
 
 Often it's desirable to define multiple sets of children, for example, if a component has a configurable title and body.
 
@@ -233,7 +235,7 @@ m(Header, [
 ])
 ```
 
-The component above makes different children look different based on where they appear in the array. It's difficult to understand the component without reading its implementation. Instead, use attributes as named parameters and reserve `children` for uniform child content:
+The component above breaks the assumption that children will be output in the same contiguous format as they are received. It's difficult to understand the component without reading its implementation. Instead, use attributes as named parameters and reserve `children` for uniform child content:
 
 ```javascript
 // PREFER

--- a/docs/components.md
+++ b/docs/components.md
@@ -171,7 +171,7 @@ Be aware that when using ES5 functions, the value of `this` in nested anonymous 
 
 Although Mithril is flexible, some code patterns are discouraged:
 
-#### Avoiding restrictive interfaces
+#### Avoid restrictive interfaces
 
 Try to keep component interfaces generic - using `attrs` and `children` directly - unless the component requires special logic to operate on input.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -169,11 +169,11 @@ Be aware that when using ES5 functions, the value of `this` in nested anonymous 
 
 ### Avoid anti-patterns
 
-Try to keep component interfaces generic by default - use custom interfaces when implementation isn't generic.
+Although Mithril is flexible, some code patterns are discouraged:
 
 #### Avoiding restrictive interfaces
 
-A component has a restrictive interface when it is unnecessarily specific in its use of attributes. Custom attributes should be used when a component has a very specific purpose or requires special internal logic, but this often isn't the case - attributes and children should be used where possible.
+Try to keep component interfaces generic - using `attrs` and `children` directly - unless the component requires special logic to operate on input.
 
 In the example below, the `button` configuration is severely limited: it does not support any events other than `onclick`, it's not styleable and it only accepts text as children (but not elements, fragments or trusted HTML).
 
@@ -188,7 +188,7 @@ var RestrictiveComponent = {
 }
 ```
 
-If the required attributes are equivalent to generic DOM attributes, it's preferable to allow passing through parameters to a component's root node, if it makes sense to do so.
+If the required attributes are equivalent to generic DOM attributes, it's preferable to allow passing through parameters to a component's root node.
 
 ```javascript
 // PREFER


### PR DESCRIPTION
@cmawhorter [pointed out on the chat](https://gitter.im/lhorie/mithril.js?at=583a4b0e89d179bf4dcc2f1c) that the component's anti-pattern documentation section '[avoid restrictive interfaces](https://github.com/lhorie/mithril.js/blob/b87cf7b28853aab4cd306afc24d7507b81027c32/docs/components.md#avoid-restrictive-interfaces)' seems to be immediately contradicted by 'avoid magic indices'.

I think the overall tone of the anti patterns section comes across as distant and dogmatic, the wording is too imperative and technical without acknowledging circumstantial nuance.

This redraft attempts to make it clearer that these two sections are intended to be read together as examples of when custom interfaces are and aren't desirable. 

Ultimately I think this subject should be taken out of 'avoid anti-patterns' and the advice be incorporated into a more comprehensive examination of the desirability of custom interfaces - specifically because it still leaves the impression of a dualistic dichotomy between wholesale injection and destructuring into the view which glosses over eg lifecycle method attributes and the advanced-level possibilities of abstract attributes that are manipulated before use in the view and /or used for other internal logic.

cc @Papipo @JAForbes @cmawhorter what do you think?