### PR TITLE
Document equality diff skip - fixes #1429

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -298,7 +298,7 @@ m.render(document.body, m(Component, {greeting: "hello"}))
 
 Conversely, for similar reasons, if a component instance is created outside of a view, future redraws will perform an equality check on the node and skip it. Therefore component instances should always be created inside views:
 
-```
+```javascript
 // AVOID
 var Counter = {
 	count: 0,
@@ -329,8 +329,8 @@ m.mount(document.body, {
 
 In the example above, clicking the counter component button will increase its state count, but its view will not be triggered because the vnode representing the component shares the same reference, and therefore the render process doesn't diff them. You should always call components in the view to ensure a new vnode is created:
 
-```
-// Prefer
+```javascript
+// PREFER
 var Counter = {
 	count: 0,
 	view: function(vnode) {

--- a/docs/hyperscript.md
+++ b/docs/hyperscript.md
@@ -408,3 +408,9 @@ var BetterListComponent = {
 	}
 }
 ```
+
+#### Avoid creating vnodes outside views
+
+When a redraw encounters a vnode which is strictly equal to the one in the previous render, it will be skipped and its contents will not be updated. While this may seem like an opportunity for performance optimisation, it should be avoided because it prevents dynamic changes in that node's tree - this leads to side-effects such as downstream lifecycle methods failing to trigger on redraw. In this sense, Mithril vnodes are immutable: new vnodes are compared to old ones; mutations to vnodes are not persisted.
+
+The component documentation contains [more detail and an example of this anti-pattern](components.md#avoid-creating-component-instances-outside-views).


### PR DESCRIPTION
An attempt at documenting the gotcha that subsequent renders will skip referentially equal vnodes, potentially leading to sections of the tree falling out of sync, lifecycle methods not triggering as expected, etc.
 
Here's a couple of jsbins illustrating the [AVOID](https://jsbin.com/nomupa/edit?js,output) and [PREFER](https://jsbin.com/kowepek/edit?js,output) examples from the component anti-patterns section.