### PR TITLE
Document array semantics and vnode equality logic in migration guide

### DIFF
--- a/docs/v1.x-migration.md
+++ b/docs/v1.x-migration.md
@@ -18,7 +18,7 @@
 - [`m.request`](#mrequest)
 - [`xlink` namespace required](#xlink-namespace-required)
 - [Nested arrays in views](#nested-arrays-in-views)
-- [Vnode immutability](#nested-arrays-in-views)
+- [Vnode equality checks](#vnode-equality-checks)
 
 ---
 
@@ -503,6 +503,6 @@ Arrays now represent [fragments](fragments.md), which are structurally significa
 
 ***
 
-## Vnode immutability
+## Vnode equality checks
 
 If a vnode is strictly equal to the vnode occupying its place in the last draw, v1.x will skip that part of the tree without checking for mutations or triggering any lifecycle methods in the subtree. The component documentation contains [more detail on this issue](components.md#avoid-creating-component-instances-outside-views).

--- a/docs/v1.x-migration.md
+++ b/docs/v1.x-migration.md
@@ -17,6 +17,8 @@
 - [Accessing route params](#accessing-route-params)
 - [`m.request`](#mrequest)
 - [`xlink` namespace required](#xlink-namespace-required)
+- [Nested arrays in views](#nested-arrays-in-views)
+- [Vnode immutability](#nested-arrays-in-views)
 
 ---
 
@@ -243,7 +245,7 @@ m.mount(document.body, {
     oninit : function(vnode) {
         // ...
     },
-    
+
     view : function(vnode) {
         // Use vnode.state instead of ctrl
         // Use vnode.attrs instead of options
@@ -492,3 +494,15 @@ m("svg",
 	m("image[xlink:href='image.gif']")
 )
 ```
+
+***
+
+## Nested arrays in views
+
+Arrays now represent [fragments](fragments.md), which are structurally significant in v1.x virtual DOM. Whereas nested arrays in v0.2.x would be flattened into one continuous list of virtual nodes for the purposes of diffing, v1.x preserves the array structure - the children of any given array are not considered siblings of those of adjacent arrays.
+
+***
+
+## Vnode immutability
+
+If a vnode is strictly equal to the vnode occupying its place in the last draw, v1.x will skip that part of the tree without checking for mutations or triggering any lifecycle methods in the subtree. The component documentation contains [more detail on this issue](components.md#avoid-creating-component-instances-outside-views).


### PR DESCRIPTION
Complements #1433 in a bid to close #1429 