### PR TITLE
Travis should lint & bundle on every build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ install:
   - npm install
   - npm install @alrra/travis-scripts@^3.0.1
 
+# Run more than just npm test
+script: npm run lint && npm run build && npm test
+
 # After a successful build create bundles & commit back to the repo
 after_success:
   - |
@@ -29,8 +32,7 @@ after_success:
                           --path-encrypted-key "./.deploy.enc"
     
     # Build & commit changes
-    $(npm bin)/commit-changes --commands "npm run build" \
-                              --commit-message "Bundled output for commit $TRAVIS_COMMIT [skip ci]" \
+    $(npm bin)/commit-changes --commit-message "Bundled output for commit $TRAVIS_COMMIT [skip ci]" \
                               --branch "$BRANCH"
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ install:
   - npm install
   - npm install @alrra/travis-scripts@^3.0.1
 
+# Lint (but don't fail build) before running tests
+before_script: npm run lint || true
+
 # Run more than just npm test
-script: npm run lint && npm run build && npm test
+script: npm run build && npm test
 
 # After a successful build create bundles & commit back to the repo
 after_success:

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ requestService.setCompletionCallback(redrawService.publish)
 m.mount = require("./mount")
 m.route = require("./route")
 m.withAttr = require("./util/withAttr")
-m.render = require( "./render").render
+m.render = require("./render").render
 m.redraw = redrawService.publish
 m.request = requestService.request
 m.jsonp = requestService.jsonp

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ requestService.setCompletionCallback(redrawService.publish)
 m.mount = require("./mount")
 m.route = require("./route")
 m.withAttr = require("./util/withAttr")
-m.render = require("./render").render
+m.render = require( "./render").render
 m.redraw = redrawService.publish
 m.request = requestService.request
 m.jsonp = requestService.jsonp


### PR DESCRIPTION
This will slow down builds a bit, but only the CI ones. Locally running `npm test ` will still just run the tests.

This will solve issues like what @pygy is running into on #1339 