### PR TITLE
Document removal of sync redraw

### DIFF
--- a/docs/v1.x-migration.md
+++ b/docs/v1.x-migration.md
@@ -21,6 +21,7 @@
 - [`xlink` namespace required](#xlink-namespace-required)
 - [Nested arrays in views](#nested-arrays-in-views)
 - [`vnode` equality checks](#vnode-equality-checks)
+- [Synchronous redraw removed](#synchronous-redraw-removed)
 
 ---
 
@@ -543,3 +544,21 @@ Arrays now represent [fragments](fragment.md), which are structurally significan
 ## `vnode` equality checks
 
 If a vnode is strictly equal to the vnode occupying its place in the last draw, v1.x will skip that part of the tree without checking for mutations or triggering any lifecycle methods in the subtree. The component documentation contains [more detail on this issue](components.md#avoid-creating-component-instances-outside-views).
+
+---
+
+## Synchronous redraw removed
+
+In v0.2.x it was possible to force mithril to redraw immediately by passing a truthy value to `m.redraw()`. This behavior complicated usage of `m.redraw()` and caused some hard-to-reason about issues and has been removed.
+
+### `v0.2.x`
+
+```javascript
+m.redraw(true); // redraws immediately & synchronously
+```
+
+### `v1.x`
+
+```javascript
+m.redraw(); // schedules a redraw on the next requestAnimationFrame tick
+```


### PR DESCRIPTION
http://mithril.js.org/mithril.redraw.html#forcing-redraw appears to be gone, based on both docs and a quick perusal of the code. This should be documented in the migration guide.