### PR TITLE
Clean up npm package some

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,20 @@
+# Configuration files
+.deploy.env
+.editorconfig
+.eslintrc.js
+.gitattributes
+.gitignore
+.travis.yml
+
+# Tests
+test-utils/
+tests/
+
+# Documentation
+docs/
+examples/
+CONTRIBUTING.md
+
+# Browser stub (use index.js w/ a bundler or mithril.js w/o one instead)
+module/
+browser.js


### PR DESCRIPTION
Currently the package being published to NPM has a bunch of cruft in it. Adding a `.npmignore` file to hopefully clear out most of it.

You can see how much it cleans up the directory after installation by comparing this diff: https://www.diffchecker.com/N11MonGi

And I've got half a mind to exclude the `docs` dir too, since I don't think most people read docs out of their `node_modules` directory.