### PR TITLE
Flesh out render exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ requestService.setCompletionCallback(redrawService.redraw)
 m.mount = require("./mount")
 m.route = require("./route")
 m.withAttr = require("./util/withAttr")
-m.render = require("./render").render
+m.render = require("./render")
+m.renderer = require("./renderer")
 m.redraw = redrawService.redraw
 m.request = requestService.request
 m.jsonp = requestService.jsonp

--- a/render.js
+++ b/render.js
@@ -1,1 +1,1 @@
-module.exports = require("./render/render")(window).render
+module.exports = require("./renderer")(window).render

--- a/render.js
+++ b/render.js
@@ -1,1 +1,1 @@
-module.exports = require("./render/render")(window)
+module.exports = require("./render/render")(window).render

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,1 @@
+module.exports = require("./render/render")


### PR DESCRIPTION
Changes:

1. Makes `m.render` & `require('mithril/render')` the same, referencing `render` prop on the pre-created renderer. They are now consistent and can't be affected by each other (previously, `require('mithril/render')` could call `setEventCallback` and affect the other).
2. Adds `require('mithril/renderer')` that exports render creator from `./render/render.js`. This makes it a supported export (as opposed to requiring `./render/render.js` which feels like accessing something internal and unstable). This helps with isomorphic use, as well as any window `mocking` requirements.