### PR TITLE
Improve event binding

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -515,15 +515,16 @@ module.exports = function($window) {
 	//event
 	function updateEvent(vnode, key, value) {
 		var element = vnode.dom
-		var callback = function(e) {
+		var callback = typeof onevent !== "function" ? value : function(e) {
 			var result = value.call(element, e)
-			if (typeof onevent === "function") onevent.call(element, e)
+			onevent.call(element, e)
 			return result
 		}
 		if (key in element) element[key] = typeof value === "function" ? callback : null
 		else {
 			var eventName = key.slice(2)
 			if (vnode.events === undefined) vnode.events = {}
+			if (vnode.events[key] === callback) return
 			if (vnode.events[key] != null) element.removeEventListener(eventName, vnode.events[key], false)
 			if (typeof value === "function") {
 				vnode.events[key] = callback


### PR DESCRIPTION
This makes event binding less wasteful, more efficient, and faster in cases when there is no `renderer.setEventCallback` registered.