### PR TITLE
[WIP] Use promises in router

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -25,7 +25,7 @@ module.exports = function($window, redrawService) {
 					if (waiting != null) update(payload, component, params, path)
 					else {
 						waiting = Promise.resolve(payload.onmatch(params, path))
-							.then(function() {update(payload, component, params, path)})
+							.then(function(comp) {update(payload, comp != null ? comp : component, params, path)})
 					}
 				}
 				else update(payload, "div", params, path)


### PR DESCRIPTION
:warning: **This is still a WIP and needs some eyeballs/opinions!** :warning:

## Background

This came up [in Gitter](https://gitter.im/lhorie/mithril.js?at=5845bfb6b4ffd59e38ec53f1) while chatting about what to do with `onmatch` and `resolve` because it's really easy to footgun yourself with the current API. Props to @barneycarroll for the idea, I just had some time to hack it out.

## Changes

1. All `onmatch` functions are wrapped in a `Promise.resolve()` so they can consume whatever return value they're given and they are always async. That seems like a reasonable standardization to me, especially in light of `m.route.set()` already being normalized to be always-async as well.
2. `m.route.set()` returns a Promise. This is intended both to work nicely with the `onmatch` changes as well as be a bit more transparent about when the actual route-change has happened. Right now the function looks sync but that is not what is actually happening under the covers.

## Examples

### Current Usage

```js
m.route(document.body, "/", {
    "/" : {
        onmatch : (resolve) => {
            if(!authed) {
                m.route.set("/login");
            }

            return resolve();
        },

        render : // ...
    },

    "/login" : // ...
});
```

### Updated Usage

```js
m.route(document.body, "/", {
    "/" : {
        onmatch : () => {
            if(!authed) return m.route.set("/login");
        ),

        render : // ...
    },

    "/login" : // ...
});
```

## Todo

- [x] Handle new `component` instances being returned from `onmatch`
- [ ] approval from @lhorie 
- [ ] approval from @barneycarroll 
- [ ] a sanity check from @pygy if possible
- [ ] lots of tests added
- [ ] some tests updated
