### PR TITLE
Rewrite router reject onmatch

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -8,6 +8,7 @@ module.exports = function($window, redrawService) {
 	var routeService = coreRouter($window)
 
 	var identity = function(v) {return v}
+	var reject = new Promise(identity)
 	var render, component, attrs, currentPath
 	var route = function(root, defaultRoute, routes) {
 		if (root == null) throw new Error("Ensure the DOM element that was passed to `m.route` is not undefined")
@@ -23,7 +24,7 @@ module.exports = function($window, redrawService) {
 			if (payload.view) update({}, payload, params, path)
 			else {
 				if (payload.onmatch) {
-					Promise.resolve(payload.onmatch(params, path)).then(function(resolved) {
+					Promise.resolve(payload.onmatch(params, path, reject)).then(function(resolved) {
 						update(payload, resolved, params, path)
 					})
 				}

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -454,15 +454,18 @@ o.spec("route", function() {
 					})
 				})
 
+
 				o("onmatch can redirect to another route", function(done) {
 					var redirected = false
-
+					var render = o.spy()
 					$window.location.href = prefix + "/a"
 					route(root, "/a", {
 						"/a" : {
-							onmatch: function() {
+							onmatch: function(params, path, reject) {
 								route.set("/b")
-							}
+								return reject
+							},
+							render: render
 						},
 						"/b" : {
 							view: function(vnode){
@@ -472,6 +475,7 @@ o.spec("route", function() {
 					})
 
 					callAsync(function() {
+						o(render.callCount).equals(0)
 						o(redirected).equals(true)
 
 						done()


### PR DESCRIPTION
This adds a forever-pending promise as third argument to `onmatch`. If you return it, `update` will not fire. Inspired by @mindeavor's #1296.

I've lazily hijacked the redirection test, which seems good enough to me... let me know if you want a distinct one.