### PR TITLE
[rewrite] (WIP) A few more tests for the router + mock fixes

### DIFF
--- a/test-utils/browserMock.js
+++ b/test-utils/browserMock.js
@@ -5,14 +5,14 @@ var domMock = require("./domMock")
 var xhrMock = require("./xhrMock")
 
 module.exports = function(env) {
-	var $window = {}
+	env = env || {}
+	var $window = env.window = {}
 
 	var dom = domMock()
 	var xhr = xhrMock()
-	var ps = pushStateMock(env)
 	for (var key in dom) if (!$window[key]) $window[key] = dom[key]
 	for (var key in xhr) if (!$window[key]) $window[key] = xhr[key]
-	for (var key in ps) if (!$window[key]) $window[key] = ps[key]
+	pushStateMock(env)
 
 	return $window
 }

--- a/test-utils/tests/index.html
+++ b/test-utils/tests/index.html
@@ -13,11 +13,13 @@
 		<script src="../../test-utils/pushStateMock.js"></script>
 		<script src="../../test-utils/xhrMock.js"></script>
 		<script src="../../test-utils/domMock.js"></script>
+		<script src="../../test-utils/browserMock.js"></script>
 		<script src="test-callAsync.js"></script>
 		<script src="test-parseURL.js"></script>
 		<script src="test-pushStateMock.js"></script>
 		<script src="test-xhrMock.js"></script>
 		<script src="test-domMock.js"></script>
+		<script src="test-browserMock.js"></script>
 
 		<script>require("../../ospec/ospec").run()</script>
 	</body>

--- a/test-utils/tests/test-browserMock.js
+++ b/test-utils/tests/test-browserMock.js
@@ -1,0 +1,40 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var browserMock = require("../../test-utils/browserMock")
+var callAsync = require("../../test-utils/callAsync")
+o.spec("browserMock", function() {
+
+	var $window
+	o.beforeEach(function() {
+		$window = browserMock()
+	})
+
+	o("Mocks DOM, pushState and XHR", function() {
+		o($window.location).notEquals(undefined)
+		o($window.document).notEquals(undefined)
+		o($window.XMLHttpRequest).notEquals(undefined)
+	})
+	o("$window.onhashchange can be reached from the pushStateMock functions", function(done) {
+		$window.onhashchange = o.spy()
+		$window.location.hash = '#a'
+
+		callAsync(function(){
+			o($window.onhashchange.callCount).equals(1)
+			done()
+		})
+	})
+	o("$window.onpopstate can be reached from the pushStateMock functions", function() {
+		$window.onpopstate = o.spy()
+		$window.history.pushState(null, null, "#a")
+		$window.history.back()
+
+		o($window.onpopstate.callCount).equals(1)
+	})
+	o("$window.onunload can be reached from the pushStateMock functions", function() {
+		$window.onunload = o.spy()
+		$window.location.href = '/a'
+
+		o($window.onunload.callCount).equals(1)
+	})
+})


### PR DESCRIPTION
I was adding tests and noticed that the mocks were inadequate to write them... Pushing one commit at a time for CI confirmation.

The description will be fleshed out once the router tests are pushed.

----

Edit... I had to rebase it, so much for individual CI reports...

So for the mocks, it turns out that the `pushState` functions didn't have a reference to `$window` in the `browserMock` because of how the latter was being built. This is now fixed. I found other mock bugs, but the fix require more extensive investigation, I'll open other issues.

When redirecting from `onmatch` if you replace 
`m.route.set('/foo')` 
with 
`callAsync(_ => m.route.set('/foo'))`
or
`$window.history.back()`,
`update` fires unless you return a pending promise. I've added inline `return new Promise(function(){})` for now, but it would be nice to provide a proper API for that.