### PR TITLE
Test branched rejection handler resolution

### DIFF
--- a/promise/tests/test-promise.js
+++ b/promise/tests/test-promise.js
@@ -403,6 +403,24 @@ o.spec("promise", function() {
 				done()
 			})
 		})
+		o("triggers all branched rejection handlers upon rejection", function(done) {
+			var promise = Promise.reject()
+			var then    = o.spy()
+			var catch1  = o.spy()
+			var catch2  = o.spy()
+			var catch3  = o.spy()
+
+			promise.catch(catch1)
+			promise.then(then, catch2).catch(catch3)
+
+			promise.then(null, function(){
+				o(catch1.callCount).equals(1, "first branch catch triggers")
+				o(then.callCount).equals(0, "second branch then resolution handler doesn't trigger")
+				o(catch2.callCount).equals(1, "second branch then rejection handler triggers")
+				o(catch3.callCount).equals(1, "second branch subseqent catch triggers")
+				done()
+			})
+		})
 		o("does not absorb resolved promise via static rejector", function(done) {
 			var promise = Promise.reject(Promise.resolve(1))
 

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -336,7 +336,7 @@ o.spec("xhr", function() {
 				}
 			})
 			var promise = xhr("/item", {background: true}).then(function() {})
-			
+
 			setTimeout(function() {
 				o(complete.callCount).equals(0)
 				done()
@@ -376,6 +376,29 @@ o.spec("xhr", function() {
 			xhr({method: "GET", url: "/item"}).catch(function(e) {
 				o(e.message).equals("error")
 			}).then(done)
+		})
+		o("triggers all branched catches upon rejection", function(done) {
+			mock.$defineRoutes({
+				"GET /item": function(request) {
+					return {status: 500, responseText: "error"}
+				}
+			})
+			var request = xhr({method: "GET", url: "/item"})
+			var then    = o.spy()
+			var catch1  = o.spy()
+			var catch2  = o.spy()
+			var catch3  = o.spy()
+
+			request.catch(catch1)
+			request.then(then, catch2).catch(catch3)
+
+			setTimeout(function(){
+				o(catch1.callCount).equals(1, "first branch catch triggers")
+				o(then.callCount).equals(0, "second branch then resolution handler doesn't trigger")
+				o(catch2.callCount).equals(1, "second branch then rejection handler triggers")
+				o(catch3.callCount).equals(1, "second branch subseqent catch triggers")
+				done()
+			}, 10)
 		})
 	})
 })


### PR DESCRIPTION
These tests validate the scenario in #1465. The tests work for Mithril's promise implementation but don't for `m.request`.