### PR TITLE
Keep useful utilities in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,20 +1,8 @@
-# Configuration files
+# Development-specific files
 .deploy.env
 .editorconfig
 .eslintrc.js
 .gitattributes
 .gitignore
 .travis.yml
-
-# Tests
-test-utils/
-tests/
-
-# Documentation
-docs/
-examples/
 CONTRIBUTING.md
-
-# Browser stub (use index.js w/ a bundler or mithril.js w/o one instead)
-module/
-browser.js


### PR DESCRIPTION
This reverts most of #1449, with the opinion that while the files relating exclusively to development, contribution and deployment aren't relevant to the NPM package, a lot of the other stuff can be useful and should stay.

The pros on keeping the NPM package extra trim:

1. As @tivac says in #1449, getting rid of cruft
2. Smaller npm downloads

On the other hand:

1. Mithril is far from needing to compete aggressively on those features compared to any other given package. If a given user suffers from the clutter or weight of their npm installs, Mithril will almost certainly be at the bottom of the list of offenders - which makes the effort to prune back kind of pyrrhic. 
2. The clutter argument is irrelevant for people who configure their IDEs / text editors to ignore the contents of `./node_modules/` - a common standard and baked-in default to the latest generation of Javascript-focussed IDEs.
3. Being able to read documentation and run tests for installed dependencies without using the internet is *great* if you do use it. It's probably true that not many people do this, but being able to open & search the documentation *specific to the installed version* in your local text editor is a feature, not a bug.

The biggest issue for me is that Mithril's zero-deps philosophy (not a popular quality metric, but a very neat one) is kind of hypocritical if you don't allow adopters the full benefit of being able to follow that lead and be just as robust and self-complete with Mithril as their sole dependency. You might argue it's kind of wilfully eccentric for Mithril to use and incorporate its own test harness, mocks and bundler when there are adequate alternatives out there with more dedicated maintenance - the counter-argument is that it's delightful & genuinely useful to have a self-contained package - and the irony is that adopters are cut off from the full benefits of this achievement when they can no longer use Mithril as a single dependency themselves.

By way of example, [Mithril Route Components](https://github.com/barneycarroll/mithril-route-components) (defunct) is able to follow Mithril's practice by example, with a test suite & continuous integration using OSPEC and the browser mock, and it only depends on Mithril. In contrast, I'm faced with the dilemma of wondering what package I should pick to learn for mocking the DOM to test [Mithril Islands](https://github.com/barneycarroll/mithril-islands). It's an obnoxious problem to have, because this otherwise lightweight plugin repo will need to get an extra dependency which may not make the same assumptions as Mithril's internals.