### PR TITLE
Expose `Vnode` as `m.vnode`

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,5 +16,6 @@ m.jsonp = requestService.jsonp
 m.parseQueryString = require("./querystring/parse")
 m.buildQueryString = require("./querystring/build")
 m.version = "bleeding-edge"
+m.vnode = require("./render/vnode")
 
 module.exports = m

--- a/render/render.js
+++ b/render/render.js
@@ -2,7 +2,7 @@
 
 var Vnode = require("../render/vnode")
 
-var render = function($window) {
+module.exports = function($window) {
 	var $doc = $window.document
 	var $emptyFragment = $doc.createDocumentFragment()
 
@@ -580,7 +580,3 @@ var render = function($window) {
 
 	return {render: render, setEventCallback: setEventCallback}
 }
-
-render.vnode = Vnode;
-
-module.exports = render;

--- a/render/render.js
+++ b/render/render.js
@@ -2,7 +2,7 @@
 
 var Vnode = require("../render/vnode")
 
-module.exports = function($window) {
+var render = function($window) {
 	var $doc = $window.document
 	var $emptyFragment = $doc.createDocumentFragment()
 
@@ -580,3 +580,7 @@ module.exports = function($window) {
 
 	return {render: render, setEventCallback: setEventCallback}
 }
+
+render.vnode = Vnode;
+
+module.exports = render;


### PR DESCRIPTION
Mostly for use in `mithril-objectify`, but may be useful in other places.

Doing this so I can make a `rewrite`-compatible version of `mithril-objectify` that doesn't have to be aware of the bundling stuff going on. It can just replace invocations of `m(...)` with `m.render.vnode(...)` and go on it's merry way. Without this I would need to detect the type of bundling environment (CJS/ES2015) and then dynamically inject a `require`/`import` statement to get access to `Vnode`. I can do that, but I'd really rather not.

I wondered about exposing this as `m.vnode` or `m._vnode` but `m.render.vnode` seemed like the most appropriate place for it.