### PR TITLE
[ospec] proper(?) stack traces for error messages with new lines embedded

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -197,7 +197,8 @@ module.exports = new function init() {
 		var status = 0
 		for (var i = 0, r; r = results[i]; i++) {
 			if (!r.pass) {
-				var stackTrace = r.error.match(/^(?:(?!Error|[\/\\]ospec[\/\\]ospec\.js).)*$/m)
+				var lflf = r.error.lastIndexOf('\n\n')
+				var stackTrace = lflf === -1 ? '' : r.error.slice(lflf + 2).replace(/[^\n]*[\/\\]ospec[\/\\]ospec\.js[^\n]*(?:\n|$)/g, '')
 				console.error(r.context + ":\n" + highlight(r.message) + (stackTrace ? "\n\n" + stackTrace + "\n\n" : ""), hasProcess ? "" : "color:red", hasProcess ? "" : "color:black")
 				status = 1
 			}


### PR DESCRIPTION
`ospec` is confused by the presence of new lines in error messages. It causes mangled stack traces.

https://runkit.com/58603d35d1b6b10013e1e652/58603d36d1b6b10013e1e653

I've added a question mark in the title because the proposed patch has only been tested in Node + OS X. Specifically, I don't know if all environments put two `\n` between the error message and the trace.