### PR TITLE
Add @externs annotation.

### DIFF
--- a/mithril.closure-compiler-externs.js
+++ b/mithril.closure-compiler-externs.js
@@ -1,3 +1,8 @@
+/**
+ * @fileoverview Closure Compiler externs for Mithril.
+ * @see http://mithril.js.org
+ * @externs
+ */
 var m = {
     "render": function () {},
     "mount": function () {},
@@ -14,4 +19,4 @@ var m = {
     "request": function () {},
     "deps": function () {},
     "component": function() {}
-}
+};


### PR DESCRIPTION
Add @externs annotation. This is required by the Closure compiler, at least when used through rules_closure: https://github.com/bazelbuild/rules_closure#closure_js_library. It is a common practice, too, eg.

https://github.com/google/closure-compiler/blob/master/externs/es5.js
https://github.com/steida/react-externs/blob/master/externs.js
