### PR TITLE
Remove o.only call to ensure other tests are run.

### DIFF
--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -8,7 +8,7 @@ new function(o) {
 
 	o.spec("ospec", function() {
 		o("skipped", function() {
-			o(1).equals(1)
+			o(true).equals(false)
 		})
 		o.only(".only()", function() {
 			o(2).equals(2)
@@ -28,7 +28,7 @@ o.spec("ospec", function() {
 		o.beforeEach(function() {b = 1})
 		o.afterEach(function() {b = 0})
 
-		o.only("assertions", function() {
+		o("assertions", function() {
 			var spy = o.spy()
 			spy(a)
 


### PR DESCRIPTION
As far as I can tell, this `o.only` is disabling the execution of all the tests in the Mithril test suite.

This pr reactivates them.

eg

```
1 assertions completed in 6ms, of which 0 failed
242 assertions completed in 16ms, of which 0 failed
```

vs

```
1 assertions completed in 6ms, of which 0 failed
5682 assertions completed in 1529ms, of which 0 failed
```