### PR TITLE
Add license banner to unuglify mithril.js

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1,5 +1,12 @@
 /* global Promise */
 
+/*
+Mithril v0.2.4
+http://mithril.js.org
+(c) 2014-2016 Leo Horie
+License: MIT
+*/
+
 ;(function (global, factory) { // eslint-disable-line
 	"use strict"
 	/* eslint-disable no-undef */


### PR DESCRIPTION
I'm using npm package manager and [gulp-uglify](https://github.com/terinjokes/gulp-uglify) module with `{preserveComments: license}` option.

Npm see mithril.js file, but mithril.js doesn't have a license comment, so no lisence comment  remains in uglified source code of my application.

Therefore I have added license comment to mithril.js file.

Thanks.