### PR TITLE
Render false as an empty string

### DIFF
--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -104,7 +104,7 @@ o.spec("component", function() {
 			visible = false
 			render(root, [{tag: component}])
 
-			o(root.firstChild.nodeValue).equals("false")
+			o(root.firstChild.nodeValue).equals("")
 		})
 		o("updates root from null to null", function() {
 			var component = {
@@ -232,7 +232,7 @@ o.spec("component", function() {
 			render(root, [{tag: component}])
 
 			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("false")
+			o(root.firstChild.nodeValue).equals("")
 		})
 		o("can return null", function() {
 			var component = {
@@ -668,7 +668,7 @@ o.spec("component", function() {
 			function init(vnode) {
 				o(vnode.state.data).deepEquals(data)
 				o(vnode.state.data).equals(data)
-				
+
 				//inherits state via prototype
 				component.x = 1
 				o(vnode.state.x).equals(1)

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -229,7 +229,7 @@ o.spec("hyperscript", function() {
 		o("handles falsy boolean single child", function() {
 			var vnode = m("div", {}, [false])
 
-			o(vnode.text).equals(false)
+			o(vnode.text).equals("")
 		})
 		o("handles null single child", function() {
 			var vnode = m("div", {}, [null])
@@ -261,7 +261,7 @@ o.spec("hyperscript", function() {
 			var vnode = m("div", {}, [false, true])
 
 			o(vnode.children[0].tag).equals("#")
-			o(vnode.children[0].children).equals(false)
+			o(vnode.children[0].children).equals("")
 			o(vnode.children[1].tag).equals("#")
 			o(vnode.children[1].children).equals(true)
 		})
@@ -353,10 +353,16 @@ o.spec("hyperscript", function() {
 			o(vnode.text).equals(true)
 		})
 		o("handles attr and single falsy boolean text child", function() {
+			var vnode = m("div", {a: "b"}, [0])
+
+			o(vnode.attrs.a).equals("b")
+			o(vnode.text).equals(0)
+		})
+		o("handles attr and single false boolean text child", function() {
 			var vnode = m("div", {a: "b"}, [false])
 
 			o(vnode.attrs.a).equals("b")
-			o(vnode.text).equals(false)
+			o(vnode.text).equals("")
 		})
 		o("handles attr and single text child unwrapped", function() {
 			var vnode = m("div", {a: "b"}, "c")

--- a/render/tests/test-normalize.js
+++ b/render/tests/test-normalize.js
@@ -48,10 +48,10 @@ o.spec("normalize", function() {
 		o(node.tag).equals("#")
 		o(node.children).equals(true)
 	})
-	o("normalizes falsy boolean into text node", function() {
+	o("normalizes falsy boolean into empty text node", function() {
 		var node = Vnode.normalize(false)
 
 		o(node.tag).equals("#")
-		o(node.children).equals(false)
+		o(node.children).equals("")
 	})
 })

--- a/render/tests/test-normalizeChildren.js
+++ b/render/tests/test-normalizeChildren.js
@@ -16,4 +16,10 @@ o.spec("normalizeChildren", function() {
 		o(children[0].tag).equals("#")
 		o(children[0].children).equals("a")
 	})
+	o("normalizes `false` values into empty string text nodes", function() {
+		var children = Vnode.normalizeChildren([false])
+
+		o(children[0].tag).equals("#")
+		o(children[0].children).equals("")
+	})
 })

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -3,7 +3,7 @@ function Vnode(tag, key, attrs, children, text, dom) {
 }
 Vnode.normalize = function(node) {
 	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)
-	if (node != null && typeof node !== "object") return Vnode("#", undefined, undefined, node, undefined, undefined)
+	if (node != null && typeof node !== "object") return Vnode("#", undefined, undefined, node === false ? "" : node, undefined, undefined)
 	return node
 }
 Vnode.normalizeChildren = function normalizeChildren(children) {


### PR DESCRIPTION
Fixes #1014

Adds a `=== false` check within `vnode.normalize` that will output an empty text node instead of one that says "false". Also updated tests for new behavior (there's a surprising number of tests checking for behavior of passing `false` as a child!).

This simplifies a lot of view code that does conditional logic.

```js
m("div", test ? [ ... ] : null)

// can now be this, assuming test is strictly false

m("div", test && [ ... ])
```

It doesn't seem like a big change but in practice it can be hugely beneficial for making deeply-nested view code easier to read.

**Note:** this does **not** match the `0.2x` behavior introduced in #1103 where `true` values are also ignored. That behavior is more consistent but seems a bit off the more I think about it. If that's the preferred behavior I'm happy to updated this PR to do that instead.