### PR TITLE
Avoid intermediary component constructor

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -95,9 +95,7 @@ module.exports = function($window) {
 		return element
 	}
 	function createComponent(vnode, hooks, ns) {
-		// For object literals since `Vnode()` always sets the `state` field.
-		if (!vnode.state) vnode.state = Object.create(vnode.tag)
-
+		vnode.state = Object.create(vnode.tag)
 		var view = vnode.tag.view
 		if (view.reentrantLock != null) return $emptyFragment
 		view.reentrantLock = true

--- a/render/render.js
+++ b/render/render.js
@@ -96,10 +96,7 @@ module.exports = function($window) {
 	}
 	function createComponent(vnode, hooks, ns) {
 		// For object literals since `Vnode()` always sets the `state` field.
-		if (!vnode.state) vnode.state = {}
-		var constructor = function() {}
-		constructor.prototype = vnode.tag
-		vnode.state = new constructor
+		if (!vnode.state) vnode.state = Object.create(vnode.tag)
 
 		var view = vnode.tag.view
 		if (view.reentrantLock != null) return $emptyFragment


### PR DESCRIPTION
Since our baseline target runtime is IE9-safe ES5, we can avoid convoluted temporary constructors and use `Object.create` instead.