### PR TITLE
[ospec:test] Bug? When several tests or specs share the same name, only one runs.

### DIFF
--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -140,4 +140,16 @@ o.spec("ospec", function() {
 			})
 		})
 	})
+	o.spec('duplicate names', function() {
+		var spy = o.spy()
+		o.spec('foo', function(){
+			o('bar', spy)
+			o('bar', spy)
+		})
+		o.spec('foo', spy)
+
+		o("let's count", function() {
+			o(spy.callCount).equals(3)
+		})
+	})
 })


### PR DESCRIPTION
It has bitten me several times now. The identical names were identical (either oversight after copy/paste or faulty operator precedence assumptions (`'foo (' + condition ? 'bar' : 'baz' + ')'` => always `'baz)'`).

```JS
o.spec('parent', function() {
    var spy = o.spy()
    o.spec('foo', function(){
        o('bar', spy)
        o('bar', spy)
    })
    o.spec('foo', spy)

    console.log("count", spy.callCount) // 1, when 3 would be expected.
})
```

I don't know if you want it to work as is, warn the user or fail the suite when some names are identical (one of the last two would make more sense to me).