### PR TITLE
[ospec] Improve the dupe detection code

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -110,15 +110,12 @@ module.exports = new function init() {
 			}
 		}
 	}
-	var dedupeCounter = 0
 	function unique(subject) {
-		var res = subject
-		if (ctx.hasOwnProperty(subject)) {
+		if (hasOwn.call(ctx, subject)) {
 			console.warn("A test or a spec named `" + subject + "` was already defined")	
-			while (ctx.hasOwnProperty(res)) res = subject + ' (' + ++dedupeCounter + ')'
-			dedupeCounter = 0
+			while (hasOwn.call(ctx, subject)) subject += '*'
 		}
-		return res
+		return subject
 	}
 	function hook(name) {
 		return function(predicate) {

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -1,7 +1,7 @@
 "use strict"
 
 module.exports = new function init() {
-	var spec = {}, subjects = [], results = [], only = null, ctx = spec, start, stack = 0, hasProcess = typeof process === "object"
+	var spec = {}, subjects = [], results = [], only = null, ctx = spec, start, stack = 0, hasProcess = typeof process === "object", hasOwn = ({}).hasOwnProperty
 
 	function o(subject, predicate) {
 		if (predicate === undefined) return new Assert(subject)
@@ -156,7 +156,7 @@ module.exports = new function init() {
 				var aKeys = Object.getOwnPropertyNames(a), bKeys = Object.getOwnPropertyNames(b)
 				if (aKeys.length !== bKeys.length) return false
 				for (var i = 0; i < aKeys.length; i++) {
-					if (!b.hasOwnProperty(aKeys[i]) || !deepEqual(a[aKeys[i]], b[aKeys[i]])) return false
+					if (!hasOwn.call(b, aKeys[i]) || !deepEqual(a[aKeys[i]], b[aKeys[i]])) return false
 				}
 				return true
 			}


### PR DESCRIPTION
It will run all tests, even if more than two share the same name. This covers the case were the attempted deduped name already exists.

AFAIK mutating a function argument can cause deopts in V8. Removing these mutations doesn't seem to affect the run time but better be safe than sorry...

At last `[\w_]` is redundant since `\w` matches `_`.