### PR TITLE
Revive m.route.param()

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -54,7 +54,7 @@ module.exports = function($window, redrawService) {
 			route.set(href, undefined, undefined)
 		}
 	}
-	route.params = function(key) {
+	route.param = function(key) {
 		if(typeof attrs !== "undefined" && typeof key !== "undefined") return attrs[key]
 		return attrs
 	}

--- a/api/router.js
+++ b/api/router.js
@@ -54,6 +54,10 @@ module.exports = function($window, redrawService) {
 			route.set(href, undefined, undefined)
 		}
 	}
+	route.params = function(key) {
+		if(typeof attrs !== "undefined" && typeof key !== "undefined") return attrs[key]
+		return attrs
+	}
 
 	return route
 }

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1208,6 +1208,9 @@ o.spec("route", function() {
 						}
 					})
 
+					o(route.params("id")).equals(undefined);
+					o(route.params()).deepEquals(undefined);
+
 					callAsync(function() {
 						o(route.params("id")).equals("1")
 						o(route.params()).deepEquals({id:"1"})

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1195,25 +1195,25 @@ o.spec("route", function() {
 					}, FRAME_BUDGET * 2)
 				})
 
-				o("m.route.params is available outside of route handlers", function(done) {
+				o("m.route.param is available outside of route handlers", function(done) {
 					$window.location.href = prefix + "/"
 
 					route(root, "/1", {
 						"/:id" : {
 							view : function() {
-								o(route.params("id")).equals("1")
+								o(route.param("id")).equals("1")
 
 								return m("div")
 							}
 						}
 					})
 
-					o(route.params("id")).equals(undefined);
-					o(route.params()).deepEquals(undefined);
+					o(route.param("id")).equals(undefined);
+					o(route.param()).deepEquals(undefined);
 
 					callAsync(function() {
-						o(route.params("id")).equals("1")
-						o(route.params()).deepEquals({id:"1"})
+						o(route.param("id")).equals("1")
+						o(route.param()).deepEquals({id:"1"})
 
 						done()
 					})

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1194,6 +1194,27 @@ o.spec("route", function() {
 						done()
 					}, FRAME_BUDGET * 2)
 				})
+
+				o("m.route.params is available outside of route handlers", function(done) {
+					$window.location.href = prefix + "/"
+
+					route(root, "/1", {
+						"/:id" : {
+							view : function() {
+								o(route.params("id")).equals("1")
+
+								return m("div")
+							}
+						}
+					})
+
+					callAsync(function() {
+						o(route.params("id")).equals("1")
+						o(route.params()).deepEquals({id:"1"})
+
+						done()
+					})
+				})
 			})
 		})
 	})


### PR DESCRIPTION
There are plenty of use-cases for having components further down the tree able to investigate the route params, and currently the only way to make that available is to pass around the `vnode.attrs` and/or stash it away somewhere. Looking at `api/router.js` those params are already kept available to anyone, so this PR revives the `m.route.param(<key>)` method from `0.2.x` to simplify that same usage in `1.0.0`.

The impetus for this is trying to port an existing `0.2.x` app of ours that has deeply-nested child components that inspect the current route state for a portion of their functionality. We could do a large refactor to make the data available in a different way but I don't think there's much point. I don't find `m.route.param()` to be a particularly offensive API, I think I just forgot to implement it back when the API layer first landed.

I'm happy to write up docs if this PR is something we actually want to land.