### PR TITLE
Fix request abort error

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -70,7 +70,7 @@ module.exports = function($window, Promise) {
 			if (typeof args.config === "function") xhr = args.config(xhr, args) || xhr
 
 			xhr.onreadystatechange = function() {
-				if (xhr.readyState === 4) {
+				if (xhr.status && xhr.readyState === 4) {
 					try {
 						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
 						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304) {

--- a/request/request.js
+++ b/request/request.js
@@ -70,6 +70,8 @@ module.exports = function($window, Promise) {
 			if (typeof args.config === "function") xhr = args.config(xhr, args) || xhr
 
 			xhr.onreadystatechange = function() {
+				// Don't throw errors on xhr.abort(). XMLHttpRequests ends up in a state of
+				// xhr.status == 0 and xhr.readyState == 4 if aborted after open, but before completion.
 				if (xhr.status && xhr.readyState === 4) {
 					try {
 						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))


### PR DESCRIPTION
Aborting an XHR request after it has been sent but not finished results in an error. To reproduce the XHR state in a browser:

```
var xhr = new XMLHttpRequest();
xhr.onreadystatechange = function() {
    console.log('readyState:', xhr.readyState, 'status:', xhr.status);
};
xhr.open('GET', '/', true);
xhr.send();
setTimeout(function(){ xhr.abort() }, 10);
```
Should make you see `readyState: 4 status: 0` in the console.

The current xhrMock in Mithril is not capable of reproducing the error.