### PR TITLE
fix: stat is undefined in some cornor case

### DIFF
--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -10,7 +10,7 @@ function traverseDirectory(pathname, callback) {
 	return new Promise(function(resolve, reject) {
 		fs.lstat(pathname, function(err, stat) {
 			if (err) reject(err)
-			if (stat.isDirectory()) {
+			if (stat && stat.isDirectory()) {
 				fs.readdir(pathname, function(err, pathnames) {
 					if (err) reject(err)
 					var promises = []


### PR DESCRIPTION
I've encountered the problem of `stat` is undefined, throw below error:

```
/home/1111hui/public_html/node_modules/ospec/bin/ospec:13
			if (stat.isDirectory()) {
			        ^

TypeError: Cannot read property 'isDirectory' of undefined
    at /home/1111hui/public_html/node_modules/ospec/bin/ospec:13:12
    at FSReqWrap.oncomplete (fs.js:123:15)
```

I've checked it's due to some unicode file names on some linux OS.

Maybe this fix is not perfect, but it works.

