### PR TITLE
Use Travis for npm publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,16 @@ install:
 - npm install @alrra/travis-scripts@^3.0.1
 
 # Bundle before running tests so the bundle is always up-to-date
-script: npm run build && npm test
+before_script: npm run build
+
+# This is the default, but leaving so it is obvious
+# script: npm test
 
 # After a successful build create bundles & commit back to the repo
 after_success:
   - |
     
-    # Only want to commit things on commits to $BRANCH
+    # Only want to commit things on $BRANCH
     if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] || [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
       echo "Artifacts only built on $BRANCH"
       exit 0
@@ -33,10 +36,11 @@ after_success:
                           --iv "$encrypted_8b86e0359d64_iv" \
                           --path-encrypted-key "./.deploy.enc"
     
-    # Build & commit changes
+    # Commit changes (if there were any) from running build earlier
     $(npm bin)/commit-changes --commit-message "Bundled output for commit $TRAVIS_COMMIT [skip ci]" \
                               --branch "$BRANCH"
 
+# Environment configuration
 env:
   global:
     # Restrict the branch this will activate on

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ env:
     - secure: Xvqvm3+PvJu/rs3jl/NNn0RWLkkLkIoPHiL0GCfVRaywgjCYVN02g54NVvIDaOfybqPmu9E6PJFVs92vhF34NMFQHf4EWskynusIGV271R2BV0i+OJBfLMuLgiwm6zRn7/Zw4JvWIUGEwcnlz0qxbqdHsS0SOR3fIkFzePickW0=
     - secure: Rf/ldEO9d4vItJhe6EmqWpFAyCARzoCb422nHnjr1hYJknnwIXpgyZ1C/7On/9o7rWPPf+8WcHC/rgjK2rthKCldzdG5I60LfWSNzap9lk3Aa4TpSCoDBuEp7JVvDr5tc3rKnBXVT71hOay7RSx1StWzXiJs9mjaeVMJzYzRT78=
 
-# Deploy to npm on successful builds
+# Deploy to npm on tagged commits that successfully build
 deploy:
   provider: npm
   email: npm@patcavit.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ env:
 deploy:
   provider: npm
   email: npm@patcavit.com
-  skip_cleanup:
+  skip_cleanup: true
   api_key:
     secure: ADElvD1oxn9GfEG7dDOggX96b36A/cGEybovAc0221CCKzv5kWCavMrtxneiJYI6N/n24abSlbM90vMfU84FEzH0Ev28dGVokRP4ad6VRkISszKlYVEP8Lds4QxfKh78jZlUxmxM0B3vmQ1kYJbTBqp3ICtaJ5ptEQHWhrLtxnc=
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_success:
     
     # Only want to commit things on $BRANCH
     if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] || [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
-      echo "Artifacts only built on $BRANCH"
+      echo "Artifacts only committed on $BRANCH"
       exit 0
     fi
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 sudo: false
 
+# Only care about running tests against latest node
 language: node_js
 node_js:
 - node
 
+# Keep node_modules around, it speeds up builds & they don't change often
 cache:
   directories:
   - node_modules
 
 # Custom install step so the travis scripts don't need to be in package.json
 install:
-  - npm install
-  - npm install @alrra/travis-scripts@^3.0.1
+- npm install
+- npm install @alrra/travis-scripts@^3.0.1
 
-# Lint (but don't fail build) before running tests
-before_script: npm run lint || true
-
-# Run more than just npm test
+# Bundle before running tests so the bundle is always up-to-date
 script: npm run build && npm test
 
 # After a successful build create bundles & commit back to the repo
@@ -46,3 +45,15 @@ env:
     # Set up GH_USER_EMAIL & GH_USER_NAME env variables used by travis-scripts package
     - secure: Xvqvm3+PvJu/rs3jl/NNn0RWLkkLkIoPHiL0GCfVRaywgjCYVN02g54NVvIDaOfybqPmu9E6PJFVs92vhF34NMFQHf4EWskynusIGV271R2BV0i+OJBfLMuLgiwm6zRn7/Zw4JvWIUGEwcnlz0qxbqdHsS0SOR3fIkFzePickW0=
     - secure: Rf/ldEO9d4vItJhe6EmqWpFAyCARzoCb422nHnjr1hYJknnwIXpgyZ1C/7On/9o7rWPPf+8WcHC/rgjK2rthKCldzdG5I60LfWSNzap9lk3Aa4TpSCoDBuEp7JVvDr5tc3rKnBXVT71hOay7RSx1StWzXiJs9mjaeVMJzYzRT78=
+
+# Deploy to npm on successful builds
+deploy:
+  provider: npm
+  email: npm@patcavit.com
+  skip_cleanup:
+  api_key:
+    secure: ADElvD1oxn9GfEG7dDOggX96b36A/cGEybovAc0221CCKzv5kWCavMrtxneiJYI6N/n24abSlbM90vMfU84FEzH0Ev28dGVokRP4ad6VRkISszKlYVEP8Lds4QxfKh78jZlUxmxM0B3vmQ1kYJbTBqp3ICtaJ5ptEQHWhrLtxnc=
+  on:
+    tags: true
+    repo: lhorie/mithril.js
+    branch: rewrite

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
 		"gendocs": "node docs/generate",
 		"lint": "eslint .",
 		"test": "node ospec/bin/ospec",
-		"cover": "istanbul cover --print both ospec/bin/ospec"
+		"posttest": "npm run lint || true",
+		"cover": "istanbul cover --print both ospec/bin/ospec",
+		"preversion": "npm run test",
+		"version": "npm run build && git add mithril.js mithril.min.js",
+		"postversion": "git push --follow-tags"
 	},
 	"devDependencies": {
 		"eslint": "^2.10.2",

--- a/package.json
+++ b/package.json
@@ -1,36 +1,36 @@
 {
-	"name": "mithril",
-	"version": "1.0.0-rc.7",
-	"description": "A framework for building brilliant applications",
-	"author": "Leo Horie",
-	"license": "MIT",
-	"main": "index.js",
-	"repository": "lhorie/mithril.js",
-	"scripts": {
-		"dev": "node bundler/cli browser.js -o mithril.js -w",
-		"build": "npm run build-browser & npm run build-min",
-		"build-browser": "node bundler/cli browser.js -o mithril.js",
-		"build-min": "node bundler/cli browser.js -o mithril.min.js -m",
-		"lintdocs": "node docs/lint",
-		"gendocs": "node docs/generate",
-		"lint": "eslint .",
-		"test": "node ospec/bin/ospec",
-		"posttest": "npm run lint || true",
-		"cover": "istanbul cover --print both ospec/bin/ospec",
-		"preversion": "npm run test",
-		"version": "npm run build && git add mithril.js mithril.min.js",
-		"postversion": "git push --follow-tags"
-	},
-	"devDependencies": {
-		"eslint": "^2.10.2",
-		"istanbul": "^0.4.3",
-		"marked": "^0.3.6"
-	},
-	"publishConfig": {
-		"tag": "rewrite"
-	},
-	"bin": {
-		"ospec": "./ospec/bin/ospec",
-		"bundle": "./bundler/bin/bundle"
-	}
+  "name": "mithril",
+  "version": "1.0.0-rc.7",
+  "description": "A framework for building brilliant applications",
+  "author": "Leo Horie",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": "lhorie/mithril.js",
+  "scripts": {
+    "dev": "node bundler/cli browser.js -o mithril.js -w",
+    "build": "npm run build-browser & npm run build-min",
+    "build-browser": "node bundler/cli browser.js -o mithril.js",
+    "build-min": "node bundler/cli browser.js -o mithril.min.js -m",
+    "lintdocs": "node docs/lint",
+    "gendocs": "node docs/generate",
+    "lint": "eslint .",
+    "test": "node ospec/bin/ospec",
+    "posttest": "npm run lint || true",
+    "cover": "istanbul cover --print both ospec/bin/ospec",
+    "preversion": "npm run test",
+    "version": "npm run build && git add mithril.js mithril.min.js",
+    "postversion": "git push --follow-tags"
+  },
+  "devDependencies": {
+    "eslint": "^2.10.2",
+    "istanbul": "^0.4.3",
+    "marked": "^0.3.6"
+  },
+  "publishConfig": {
+    "tag": "rewrite"
+  },
+  "bin": {
+    "ospec": "./ospec/bin/ospec",
+    "bundle": "./bundler/bin/bundle"
+  }
 }


### PR DESCRIPTION
New release process:

1. Programmer enters `npm version <type-of-change or new version> -m "v%s"`

Everything else is fully automated, here's what will happen.

1. Tests are run
3. Linting is run (but doesn't fail build)
4. Version number in `package.json` is incremented
5. New bundles are generated using updated version
6. `git add` called on bundle output
7. `package.json` and updated bundles are committed to git
8. previous commit is tagged using new version number
9. `git push --follow-tags` pushes up new version commit & tag to github
10. Travis sees new release, starts build
11. Travis generates new bundles before running tests
12. Travis runs tests
13. Travis lints files (but can't fail build)
13. If build fails, abort
14. Build succeeded, so travis will commit back any changes to the repo (but there won't be any)
15. Travis sees that this commit has a tag associated with it
16. Travis will use the encrypted npm creds in `.travis.yml` to publish a new version to npm

😩 phew, that's a lot of work that a human never has to do again. This is basically the process I use to release most of the packages I maintain on npm and it's super nice to not really have to think about it. So long as you use `npm version` (the `-m "v%s"` isn't required but looks nicer as a tag name IMO) everything else just goes w/o much effort.

There's a little bit of duplicated effort between the local process and travis, it's mainly to ensure that the commit tagged `v1.0.0-rc.8` actually points to the commit that bumped `package.json` and `m.version` in `mithril.js`/`mithril.min.js` to the new version. Otherwise there'd be a weird mismatch that I think people would find confusing.