### PR TITLE
docs: Document release process & reformat .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,19 @@ after_success:
     # Only want to commit when building a push on whatever $BRANCH is
     if [ "$TRAVIS_EVENT_TYPE" == "push" ] && \
        [ "$TRAVIS_BRANCH" == "$BRANCH" ] && \
-       [ "$TRAVIS_REPO_SLUG" == "$REPO" ]; then
+       [ "$TRAVIS_REPO_SLUG" == "$REPO" ]
+    then
       # Set up SSH environment
-      $(npm bin)/set-up-ssh --key "$encrypted_8b86e0359d64_key" \
-                            --iv "$encrypted_8b86e0359d64_iv" \
-                            --path-encrypted-key "./.deploy.enc"
+      $(npm bin)/set-up-ssh \
+        --key "$encrypted_8b86e0359d64_key" \
+        --iv "$encrypted_8b86e0359d64_iv" \
+        --path-encrypted-key "./.deploy.enc"
       
       # Commit changes (if there were any) from running build earlier
-      $(npm bin)/commit-changes --commands "echo committing" \
-                                --commit-message "Bundled output for commit $TRAVIS_COMMIT [skip ci]" \
-                                --branch "$BRANCH"
+      $(npm bin)/commit-changes \
+        --commands "echo committing" \
+        --commit-message "Bundled output for commit $TRAVIS_COMMIT [skip ci]" \
+        --branch "$BRANCH"
     else
       echo "Not submitting build artifacts"
     fi

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,34 @@
+# Releasing
+
+Releasing new builds of mithril is mostly automated via `npm version`
+
+## Publishing to NPM
+
+1. `npm version <major|minor|patch|semver> -m "v%s"`
+
+All further steps are automated and run as follows:
+
+2. Tests are run
+3. Linting is run (but doesn't fail build)
+4. Version number in package.json is incremented
+5. New bundles are generated using updated version
+6. `git add` called on bundle output
+7. `package.json` and updated bundles are committed to git
+8. previous commit is tagged using new version number
+9. `git push --follow-tags` pushes up new version commit & tag to github
+10. Travis sees new release, starts build
+11. Travis generates new bundles before running tests
+12. Travis runs tests
+13. Travis lints files (but can't fail build)
+14. If build fails, abort
+15. Build succeeded, so travis will commit back any changes to the repo (but there won't be any)
+16. Travis sees that this commit has a tag associated with it
+17. Travis will use the encrypted npm creds in `.travis.yml` to publish a new version to npm
+
+## Publishing a GitHub release
+
+**TODO**
+
+## Updating `docs/change-log.md`
+
+**TODO**


### PR DESCRIPTION
Don't love pushing straight to your repo, so doing this via PR.

This is an attempt to make `.travis.yml` easier to read and also pull the docs from #1538 and making them slightly more permanent. I don't want to presume on the process for setting up the GitHub Release or editing `change-log.md` so left those as a `TODO`.