### PR TITLE
fix: ospec global bin runs local modules instead of global one

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 
-[*.js]
+[{ospec,*.js}]
 indent_style = tab
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/ospec/bin/cli-spec/tests/dummy.js
+++ b/ospec/bin/cli-spec/tests/dummy.js
@@ -1,0 +1,2 @@
+var o = require('ospec')
+o(1).equals(1)

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -3,8 +3,6 @@
 var fs = require("fs")
 var path = require("path")
 
-var o = require("../ospec")
-
 function traverseDirectory(pathname, callback) {
 	pathname = pathname.replace(/\\/g, "/")
 	return new Promise(function(resolve, reject) {
@@ -36,7 +34,13 @@ traverseDirectory(".", function(pathname, stat, children) {
 		require(path.normalize(process.cwd()) + "/" + pathname)
 	}
 })
-.then(o.run)
+.then(function () {
+	for (var modulePath in require.cache) {
+		if (/\/ospec\.js$/.test(modulePath)) {
+			require(modulePath).run()
+		}
+	}
+})
 .catch(function(e) {
 	console.log(e.stack)
 })

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -35,11 +35,12 @@ traverseDirectory(".", function(pathname, stat, children) {
 	}
 })
 .then(function () {
-	if (/\/ospec\.js$/.test(modulePath)) {
-		var instance = require(modulePath)
-		if (typeof instance=='function' &&
-				instance.spec && instance.run) {
-			instance.run()
+	for (var modulePath in require.cache) {
+		if (/\/ospec\.js$/.test(modulePath)) {
+			var instance = require(modulePath)
+			if (typeof instance=='function' && instance.spec && instance.run) {
+				instance.run()
+			}
 		}
 	}
 })

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -35,9 +35,11 @@ traverseDirectory(".", function(pathname, stat, children) {
 	}
 })
 .then(function () {
-	for (var modulePath in require.cache) {
-		if (/\/ospec\.js$/.test(modulePath)) {
-			require(modulePath).run()
+	if (/\/ospec\.js$/.test(modulePath)) {
+		var instance = require(modulePath)
+		if (typeof instance=='function' &&
+				instance.spec && instance.run) {
+			instance.run()
 		}
 	}
 })

--- a/ospec/bin/tests/test-cli.js
+++ b/ospec/bin/tests/test-cli.js
@@ -1,0 +1,30 @@
+'use strict'
+
+var proc = require('child_process')
+var path = require('path')
+var fs = require('fs')
+
+var cliPath = '../ospec'
+var ospecPath = '../../ospec.js'
+var testPath = '../cli-spec/'
+
+// make specDir has it's own ospec space
+if (!fs.existsSync(dir(testPath + 'node_modules')))
+	fs.mkdirSync(dir(testPath + 'node_modules'))
+if (fs.existsSync(dir(testPath + 'node_modules/ospec.js')))
+	fs.unlinkSync(dir(testPath + 'node_modules/ospec.js'))
+fs.linkSync(dir(ospecPath), dir(testPath + 'node_modules/ospec.js'))
+
+var o = require(ospecPath)
+o.spec('ospec cli', function () {
+	o('basic', function (done) {
+		proc.exec(cliPath, {cwd: dir(testPath)}, function (e, out) {
+			o(/^1 assertions completed.* 0 failed/.test(out)).equals(true)
+			done(e)
+		})
+	})
+})
+
+function dir(name) {
+	return path.join(__dirname, name)
+}


### PR DESCRIPTION
This PR fix the `npm i -g ospec` run with nothing problem

Also, it can allow different tests use different ospec local modules, and call the `o.run` each other.

