### PR TITLE
#1547 followup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 
-[*.js]
+[{ospec,*.js}]
 indent_style = tab
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/ospec/bin/cli-spec/test-utils/ospec.js
+++ b/ospec/bin/cli-spec/test-utils/ospec.js
@@ -1,0 +1,3 @@
+var o = require('ospec')
+var instance = module.exports = o.new()
+o('runs', instance.run)

--- a/ospec/bin/cli-spec/tests/dummy.js
+++ b/ospec/bin/cli-spec/tests/dummy.js
@@ -1,5 +1,10 @@
 var o = require('../test-utils/ospec')
 
+var path = require('path')
+
+// ensure that this only runs as part of the `cli-spec` tests.
+o(process.cwd()).equals(path.join(__dirname, '..'))
+
 var runs = 0
 o('runs only once', function(){
 	o(++runs).equals(1)

--- a/ospec/bin/cli-spec/tests/dummy.js
+++ b/ospec/bin/cli-spec/tests/dummy.js
@@ -1,0 +1,2 @@
+var o = require('ospec')
+o(1).equals(1)

--- a/ospec/bin/cli-spec/tests/dummy.js
+++ b/ospec/bin/cli-spec/tests/dummy.js
@@ -1,2 +1,6 @@
-var o = require('ospec')
-o(1).equals(1)
+var o = require('../test-utils/ospec')
+
+var runs = 0
+o('runs only once', function(){
+	o(++runs).equals(1)
+})

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -3,8 +3,6 @@
 var fs = require("fs")
 var path = require("path")
 
-var o = require("../ospec")
-
 function traverseDirectory(pathname, callback) {
 	pathname = pathname.replace(/\\/g, "/")
 	return new Promise(function(resolve, reject) {
@@ -36,7 +34,13 @@ traverseDirectory(".", function(pathname, stat, children) {
 		require(path.normalize(process.cwd()) + "/" + pathname)
 	}
 })
-.then(o.run)
+.then(function () {
+	for (var modulePath in require.cache) {
+		if (/\/ospec\.js$/.test(modulePath)) {
+			require(modulePath).run()
+		}
+	}
+})
 .catch(function(e) {
 	console.log(e.stack)
 })

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -35,11 +35,12 @@ traverseDirectory(".", function(pathname, stat, children) {
 	}
 })
 .then(function () {
-	if (/\/ospec\.js$/.test(modulePath)) {
-		var instance = require(modulePath)
-		if (typeof instance=='function' &&
-				instance.spec && instance.run) {
-			instance.run()
+	for (var modulePath in require.cache) {
+		if (/\/ospec\.js$/.test(modulePath)) {
+			var instance = require(modulePath)
+			if (typeof instance=='function' && instance.spec && instance.run) {
+				instance.run()
+			}
 		}
 	}
 })

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -35,9 +35,11 @@ traverseDirectory(".", function(pathname, stat, children) {
 	}
 })
 .then(function () {
-	for (var modulePath in require.cache) {
-		if (/\/ospec\.js$/.test(modulePath)) {
-			require(modulePath).run()
+	if (/\/ospec\.js$/.test(modulePath)) {
+		var instance = require(modulePath)
+		if (typeof instance=='function' &&
+				instance.spec && instance.run) {
+			instance.run()
 		}
 	}
 })

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 var fs = require("fs")
 var path = require("path")
 
@@ -38,7 +37,7 @@ traverseDirectory(".", function(pathname, stat, children) {
 	for (var modulePath in require.cache) {
 		if (/\/ospec\.js$/.test(modulePath)) {
 			var instance = require(modulePath)
-			if (typeof instance=='function' && instance.spec && instance.run) {
+			if (typeof instance=='function' && instance.spec && instance.run && instance._main_instance) {
 				instance.run()
 			}
 		}

--- a/ospec/bin/tests/test-cli.js
+++ b/ospec/bin/tests/test-cli.js
@@ -1,0 +1,30 @@
+'use strict'
+
+var proc = require('child_process')
+var path = require('path')
+var fs = require('fs')
+
+var cliPath = '../ospec'
+var ospecPath = '../../ospec.js'
+var testPath = '../cli-spec/'
+
+// make specDir has it's own ospec space
+if (!fs.existsSync(dir(testPath + 'node_modules')))
+	fs.mkdirSync(dir(testPath + 'node_modules'))
+if (fs.existsSync(dir(testPath + 'node_modules/ospec.js')))
+	fs.unlinkSync(dir(testPath + 'node_modules/ospec.js'))
+fs.linkSync(dir(ospecPath), dir(testPath + 'node_modules/ospec.js'))
+
+var o = require(ospecPath)
+o.spec('ospec cli', function () {
+	o('basic', function (done) {
+		proc.exec(cliPath, {cwd: dir(testPath)}, function (e, out) {
+			o(/^1 assertions completed.* 0 failed/.test(out)).equals(true)
+			done(e)
+		})
+	})
+})
+
+function dir(name) {
+	return path.join(__dirname, name)
+}

--- a/ospec/bin/tests/test-cli.js
+++ b/ospec/bin/tests/test-cli.js
@@ -15,15 +15,17 @@ if (fs.existsSync(dir(testPath + 'node_modules/ospec.js')))
 	fs.unlinkSync(dir(testPath + 'node_modules/ospec.js'))
 fs.linkSync(dir(ospecPath), dir(testPath + 'node_modules/ospec.js'))
 
+
 var o = require(ospecPath)
 o.spec('ospec cli', function () {
 	o('basic', function (done) {
 		proc.exec(cliPath, {cwd: dir(testPath)}, function (e, out) {
-			o(/^1 assertions completed.* 0 failed/.test(out)).equals(true)
+			o(/^1 assertions completed.* 0 failed\r?\n0 assertions completed.* 0 failed\r?\n$/.test(out)).equals(true)
 			done(e)
 		})
 	})
 })
+
 
 function dir(name) {
 	return path.join(__dirname, name)

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -227,3 +227,5 @@ module.exports = new function init() {
 
 	return o
 }
+
+module.exports._main_instance = true


### PR DESCRIPTION
Once again GH won't let me send a PR to a fork... @futurist, feel free to pull this and rebase your branch on top of it.

More is coming soon.... edit: done.

@futurist, your current setup relies on a race condition between `ospec/bin/tests/test-cli.js` and `ospec/bin/cli-spec/tests/dummy.js` that are both run by the main test runner.

Luckily, `ospec/bin/ospec` does a breadth first traversal of the directory tree and thus the former runs before the latter and the `node_module` directory has been created, but if that were to change the main test suite would break.

We need to ensure that the cli tests are hidden when the main suite is run. I've tried to fix that by renaming `ospec/bin/cli-spec/tests` to `ospec/bin/cli-spec/toast`, then swap the names back and forth in `ospec/bin/tests/test-cli.js` , but I run into weird issues where I get `Error: ENOENT: no such file or directory, lstat 'ospec/bin/cli-spec/toast/dummy.js'` even though that path is never required or opened explicitly...

I'll let you fix that one :-)