### PR TITLE
Fix docs text size variations on mobile webkit

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,4 @@
+body {-webkit-text-size-adjust: 100%;}
 body,table,h5 {font:normal 16px 'Open Sans';}
 header,main {margin:auto;max-width:1000px;}
 header section {position:absolute;width:250px;}


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![before_iphone6](https://cloud.githubusercontent.com/assets/83627/22462316/b2ec056e-e7a4-11e6-97e3-1bd3b9b0a212.jpg) | ![after_iphone6](https://cloud.githubusercontent.com/assets/83627/22462318/b4f74d46-e7a4-11e6-9357-9eaba2bb4dff.jpg) |
