### PR TITLE
Update README.md to clarify speed comparison chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It's small (< 8kb gzip), fast and provides routing and XHR utilities out of the 
 		<div style="animation:grow 1.35s;background:#1e5799;height:3px;margin:0 10px 10px 0;transform-origin:0;width:68%"></div>
 	</div>
 	<div style="width:50%;">
-		<h5>Performance</h5>
+		<h5>Rendering Time</h5>
 		<small>Mithril (6.4ms)</small>
 		<div style="animation:grow 0.64s;background:#1e5799;height:3px;margin:0 10px 10px 0;transform-origin:0;width:24%;"></div>
 		<small style="color:#aaa;">Vue (9.8ms)</small>


### PR DESCRIPTION
The use of the word "Performance" can be confusing in the speed comparison chart, because a shorter line means faster rendering and so higher performance -- compared to interpreting that performance line as operations per unit time at a first glance. "Rendering Time" as suggested on gitter by @brlewis makes clear that a shorter line is better.