### PR TITLE
Allow falsey operations for vnode style & events

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -495,7 +495,7 @@ module.exports = function($window) {
 	//style
 	function updateStyle(element, old, style) {
 		if (old === style) element.style.cssText = "", old = null
-		if (style == null) element.style.cssText = ""
+		if (!style) element.style.cssText = ""
 		else if (typeof style === "string") element.style.cssText = style
 		else {
 			if (typeof old === "string") element.style.cssText = ""
@@ -521,7 +521,7 @@ module.exports = function($window) {
 		if (key in element) element[key] = typeof value === "function" ? callback : null
 		else {
 			var eventName = key.slice(2)
-			if (vnode.events === undefined) vnode.events = {}
+			if (!vnode.events) vnode.events = {}
 			if (vnode.events[key] === callback) return
 			if (vnode.events[key] != null) element.removeEventListener(eventName, vnode.events[key], false)
 			if (typeof value === "function") {


### PR DESCRIPTION
Just as vnodes tolerate `( potentiallyFalseyValue && vnode )`, this allows 
```javascript
m( 'element', {
  style : active && { background: 'yellow' },
  events : active && { onkeydown : captureKey }
} )
```

Again, this is to facilitate declarative conditional logic in hyperscript, thus avoiding the need to check for trailing negative outcomes in ternary operators, temporary assignments, etc.