### PR TITLE
Avoid inaccurately inferring xhr abort.

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -2,6 +2,8 @@
 
 var buildQueryString = require("../querystring/build")
 
+var FILE_PROTOCOL_REGEX = new RegExp('^file://', 'i')
+
 module.exports = function($window, Promise) {
 	var callbackCount = 0
 
@@ -86,7 +88,7 @@ module.exports = function($window, Promise) {
 				if (xhr.readyState === 4) {
 					try {
 						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
-						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304) {
+						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || FILE_PROTOCOL_REGEX.test(args.url)) {
 							resolve(cast(args.type, response))
 						}
 						else {

--- a/request/request.js
+++ b/request/request.js
@@ -53,7 +53,16 @@ module.exports = function($window, Promise) {
 			if (useBody) args.data = args.serialize(args.data)
 			else args.url = assemble(args.url, args.data)
 
-			var xhr = new $window.XMLHttpRequest()
+			var xhr = new $window.XMLHttpRequest(),
+				aborted = false,
+				_abort = xhr.abort
+
+
+			xhr.abort = function abort() {
+				aborted = true
+				_abort.call(xhr)
+			}
+
 			xhr.open(args.method, args.url, typeof args.async === "boolean" ? args.async : true, typeof args.user === "string" ? args.user : undefined, typeof args.password === "string" ? args.password : undefined)
 
 			if (args.serialize === JSON.stringify && useBody) {
@@ -71,9 +80,10 @@ module.exports = function($window, Promise) {
 			if (typeof args.config === "function") xhr = args.config(xhr, args) || xhr
 
 			xhr.onreadystatechange = function() {
-				// Don't throw errors on xhr.abort(). XMLHttpRequests ends up in a state of
-				// xhr.status == 0 and xhr.readyState == 4 if aborted after open, but before completion.
-				if (xhr.status && xhr.readyState === 4) {
+				// Don't throw errors on xhr.abort().
+				if(aborted) return
+
+				if (xhr.readyState === 4) {
 					try {
 						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
 						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304) {

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -390,6 +390,22 @@ o.spec("xhr", function() {
 				o(xhr.getRequestHeader("Accept")).equals("application/json, text/*")
 			}
 		})
+		o("doesn't fail on abort", function(done) {
+			var s = new Date
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return {status: 200, responseText: JSON.stringify({a: 1})}
+				}
+			})
+			var failed = false
+			xhr({method: "GET", url: "/item", config: function (xhr) { setTimeout(function() { xhr.abort() }, 0) }}).catch(function() {
+				failed = true
+			}).then(function() {
+				o(failed).equals(false)
+			}).then(function() {
+				done()
+			})
+		})
 		/*o("data maintains after interpolate", function() {
 			mock.$defineRoutes({
 				"PUT /items/:x": function() {
@@ -462,6 +478,16 @@ o.spec("xhr", function() {
 					done()
 				})
 			})
+		})
+		o("rejects on cors-like error", function(done) {
+			mock.$defineRoutes({
+				"GET /item": function(request) {
+					return {status: 0}
+				}
+			})
+			xhr({method: "GET", url: "/item"}).catch(function(e) {
+				o(e instanceof Error).equals(true)
+			}).then(done)
 		})
 	})
 })

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -406,6 +406,23 @@ o.spec("xhr", function() {
 				done()
 			})
 		})
+		o("doesn't fail on file:// status 0", function(done) {
+			var s = new Date
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return {status: 0, responseText: JSON.stringify({a: 1})}
+				}
+			})
+			var failed = false
+			xhr({method: "GET", url: "file:///item"}).catch(function() {
+				failed = true
+			}).then(function(data) {
+				o(failed).equals(false)
+				o(data).deepEquals({a: 1})
+			}).then(function() {
+				done()
+			})
+		})
 		/*o("data maintains after interpolate", function() {
 			mock.$defineRoutes({
 				"PUT /items/:x": function() {

--- a/test-utils/xhrMock.js
+++ b/test-utils/xhrMock.js
@@ -15,6 +15,7 @@ module.exports = function() {
 		XMLHttpRequest: function XMLHttpRequest() {
 			var args = {}
 			var headers = {}
+			var aborted = false
 			this.setRequestHeader = function(header, value) {
 				headers[header] = value
 			}
@@ -32,17 +33,24 @@ module.exports = function() {
 			}
 			this.send = function(body) {
 				var self = this
-				var handler = routes[args.method + " " + args.pathname] || serverErrorHandler.bind(null, args.pathname)
-				var data = handler({url: args.pathname, query: args.search || {}, body: body || null})
+				if(!aborted) {
+					var handler = routes[args.method + " " + args.pathname] || serverErrorHandler.bind(null, args.pathname)
+					var data = handler({url: args.pathname, query: args.search || {}, body: body || null})
+					self.status = data.status
+					self.responseText = data.responseText
+				} else {
+					self.status = 0
+				}
 				self.readyState = 4
-				self.status = data.status
-				self.responseText = data.responseText
 				if (args.async === true) {
 					var s = new Date
 					callAsync(function() {
 						if (typeof self.onreadystatechange === "function") self.onreadystatechange()
 					})
 				}
+			}
+			this.abort = function() {
+				aborted = true
 			}
 		},
 		document: {


### PR DESCRIPTION
The xhr.status can equal zero in non-abort scenarios, eg timeout or CORS failure.

The current handling means that the request promise doesn't reject for a CORS failure or for a timeout.

Rather than inferring that xhr.status === 0 means abort, track the invocation of the abort function instead.

Mostly making this PR as a RFC... (And to check I didn't miss something logical :-) )