### PR TITLE
[ospec] Make some moise when `o.only()` is called

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -18,7 +18,10 @@ module.exports = new function init() {
 		predicate()
 		ctx = parent
 	}
-	o.only = function(subject, predicate) {o(subject, only = predicate)}
+	o.only = function(subject, predicate, silent) {
+		if (!silent) console.log(highlight("/!\\ WARNING /!\\ o.only() mode"))
+		o(subject, only = predicate)
+	}
 	o.spy = function(fn) {
 		var spy = function() {
 			spy.this = this

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -12,7 +12,7 @@ new function(o) {
 		})
 		o.only(".only()", function() {
 			o(2).equals(2)
-		})
+		}, true)
 	})
 
 	o.run()


### PR DESCRIPTION
This outputs a red `/!\ WARNING /!\ o.only() mode` banner to `stdout` when `o.only()` is used.