### PR TITLE
API docs signature fixes for route resolver, jsonp, fragment

### DIFF
--- a/docs/fragment.md
+++ b/docs/fragment.md
@@ -35,11 +35,11 @@ Generates a fragment [vnode](vnodes.md)
 
 `vnode = m.fragment(attrs, children)`
 
-Argument    | Type                                 | Required | Description
------------ | ------------------------------------ | -------- | ---
-`attrs`     | `Object`                             | Yes      | A map of attributes
-`children`  | `Array<Vnode>|String|Number|Boolean` | Yes      | A list of vnodes
-**returns** | `Vnode`                              |          | A fragment [vnode](vnodes.md)
+Argument    | Type                                                | Required | Description
+----------- | --------------------------------------------------- | -------- | ---
+`attrs`     | `Object`                                            | Yes      | A map of attributes
+`children`  | `Array<Vnode|String|Number|Boolean|null|undefined>` | Yes      | A list of vnodes
+**returns** | `Vnode`                                             |          | A fragment [vnode](vnodes.md)
 
 [How to read signatures](signatures.md)
 

--- a/docs/jsonp.md
+++ b/docs/jsonp.md
@@ -36,6 +36,7 @@ Argument               | Type                              | Required | Descript
 `options.type`         | `any = Function(any)`             | No       | A constructor to be applied to each object in the response. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function).
 `options.callbackName` | `String`                          | No       | The name of the function that will be called as the callback. Defaults to a randomized string (e.g. `_mithril_6888197422121285_0({a: 1})`
 `options.callbackKey`  | `String`                          | No       | The name of the querystring parameter name that specifies the callback name. Defaults to `callback` (e.g. `/someapi?callback=_mithril_6888197422121285_0`)
+`options.background`   | `Boolean`                         | No       | If `false`, redraws mounted components upon completion of the request. If `true`, it does not. Defaults to `false`.
 **returns**            | `Promise`                         |          | A promise that resolves to the response data, after it has been piped through `type` method
 
 [How to read signatures](signatures.md)

--- a/docs/route.md
+++ b/docs/route.md
@@ -143,7 +143,7 @@ Argument            | Type                 | Description
 ------------------- | -------------------- | -----------
 `vnode`             | `Object`             | A [vnode](vnodes.md) whose attributes object contains routing parameters. If onmatch does not return a component or a promise that resolves to a component, the vnode's `tag` field defaults to `"div"`
 `vnode.attrs`       | `Object`             | A map of URL parameter values
-**returns**         | `Vnode|Array<Vnode>` | Returns a vnode or array of vnodes
+**returns**         | `Array<Vnode>|Vnode` | The [vnodes](vnodes.md) to be rendered
 
 ---
 

--- a/docs/route.md
+++ b/docs/route.md
@@ -123,11 +123,11 @@ For more information on `onmatch`, see the [advanced component resolution](#adva
 
 `routeResolver.onmatch(args, requestedPath)`
 
-Argument        | Type                           | Description
---------------- | ------------------------------ | ---
-`args`          | `Object`                       | The [routing parameters](#routing-parameters)
-`requestedPath` | `String`                       | The router path requested by the last routing action, including interpolated routing parameter values, but without the prefix. When `onmatch` is called, the resolution for this path is not complete and `m.route.get()` still returns the previous path.
-**returns**     | `Component|Promise<Component>` | Returns a component or a promise that resolves to a component
+Argument        | Type                                     | Description
+--------------- | ---------------------------------------- | ---
+`args`          | `Object`                                 | The [routing parameters](#routing-parameters)
+`requestedPath` | `String`                                 | The router path requested by the last routing action, including interpolated routing parameter values, but without the prefix. When `onmatch` is called, the resolution for this path is not complete and `m.route.get()` still returns the previous path.
+**returns**     | `Component|Promise<Component>|undefined` | Returns a component or a promise that resolves to a component
 
 If `onmatch` returns a component or a promise that resolves to a component, this component is used as the `vnode.tag` for the first argument in the RouteResolver's `render` method. Otherwise, `vnode.tag` is set to `"div"`. Similarly, if the `onmatch` method is omitted, `vnode.tag` is also `"div"`.
 
@@ -139,11 +139,11 @@ The `render` method is called on every redraw for a matching route. It is simila
 
 `vnode = routeResolve.render(vnode)`
 
-Argument            | Type            | Description
-------------------- | --------------- | -----------
-`vnode`             | `Object`        | A [vnode](vnodes.md) whose attributes object contains routing parameters. If onmatch does not return a component or a promise that resolves to a component, the vnode's `tag` field defaults to `"div"`
-`vnode.attrs`       | `Object`        | A map of URL parameter values
-**returns**         | `Vnode`         | Returns a vnode
+Argument            | Type                 | Description
+------------------- | -------------------- | -----------
+`vnode`             | `Object`             | A [vnode](vnodes.md) whose attributes object contains routing parameters. If onmatch does not return a component or a promise that resolves to a component, the vnode's `tag` field defaults to `"div"`
+`vnode.attrs`       | `Object`             | A map of URL parameter values
+**returns**         | `Vnode|Array<Vnode>` | Returns a vnode or array of vnodes
 
 ---
 
@@ -501,7 +501,7 @@ For the sake of simplicity, in the example above, the user's logged in status is
 var Auth = {
 	username: "",
 	password: "",
-	
+
 	setUsername: function(value) {
 		Auth.username = value
 	},


### PR DESCRIPTION
Fixes should be self-explanatory I think. I've been testing a lot of API signatures while I finish up some loose ends with the typescript definitions.

I made an incomplete change to RouteResolver's `render` signature, though to be more correct it would be more like:

**returns** `Vnode|String|Number|Boolean|null|undefined|Array<Vnode|String|Number|Boolean|null|undefined>`

which gets kinda long for the table. Still it's useful to know more concretely what the types are.

I wonder if it would be useful to describe a "Renderable" type somewhere and reference that wherever needed.