### PR TITLE
[ospec] stricter valid context for test definitions and assertions

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -1,11 +1,18 @@
 "use strict"
 
 module.exports = new function init() {
-	var spec = {}, subjects = [], results = [], only = null, ctx = spec, start, stack = 0, nextTickish, hasProcess = typeof process === "object", hasOwn = ({}).hasOwnProperty
+	var spec = {}, subjects = [], results, only = null, ctx = spec, start, stack = 0, nextTickish, hasProcess = typeof process === "object", hasOwn = ({}).hasOwnProperty
 
 	function o(subject, predicate) {
-		if (predicate === undefined) return new Assert(subject)
-		ctx[unique(subject)] = predicate
+		if (predicate === undefined) {
+			if (results == null) throw new Error("Assertions should not occur outside test definitions")
+			return new Assert(subject)
+		}
+		else if (results == null) {
+			ctx[unique(subject)] = predicate
+		} else {
+			throw new Error("Test definition shouldn't be nested. To group tests use `o.spec()`")
+		}
 	}
 	o.before = hook("__before")
 	o.after = hook("__after")
@@ -40,6 +47,7 @@ module.exports = new function init() {
 		return spy
 	}
 	o.run = function() {
+		results = []
 		start = new Date
 		test(spec, [], [], report)
 

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -20,7 +20,7 @@ new function(o) {
 
 o.spec("ospec", function() {
 	o.spec("sync", function() {
-		var a = 0, b = 0
+		var a = 0, b = 0, illegalAssertionThrows = false
 
 		o.before(function() {a = 1})
 		o.after(function() {a = 0})
@@ -28,7 +28,15 @@ o.spec("ospec", function() {
 		o.beforeEach(function() {b = 1})
 		o.afterEach(function() {b = 0})
 
+		try {o('illegal assertion')} catch (e) {illegalAssertionThrows = true}
+
 		o("assertions", function() {
+			var nestedTestDeclarationThrows = false
+			try {o('illegal nested test', function(){})} catch (e) {nestedTestDeclarationThrows = true}
+
+			o(illegalAssertionThrows).equals(true)
+			o(nestedTestDeclarationThrows).equals(true)
+
 			var spy = o.spy()
 			spy(a)
 


### PR DESCRIPTION
This makes nested test definitions and assertions out of test blocks throw an error.

#1339 for the rationale (even though #1617 makes this partly redundant).