### PR TITLE
Let `m.mount` and `m.route` accept class and factory components.

### DIFF
--- a/api/mount.js
+++ b/api/mount.js
@@ -10,7 +10,7 @@ module.exports = function(redrawService) {
 			return
 		}
 		
-		if (component.view == null) throw new Error("m.mount(element, component) expects a component, not a vnode")
+		if (component.view == null && typeof component !== "function") throw new Error("m.mount(element, component) expects a component, not a vnode")
 		
 		var run = function() {
 			redrawService.render(root, Vnode(component))

--- a/api/router.js
+++ b/api/router.js
@@ -21,11 +21,12 @@ module.exports = function($window, redrawService) {
 		routeService.defineRoutes(routes, function(payload, params, path) {
 			var update = lastUpdate = function(routeResolver, comp) {
 				if (update !== lastUpdate) return
-				component = comp != null && typeof comp.view === "function" ? comp : "div", attrs = params, currentPath = path, lastUpdate = null
+				component = comp != null && (typeof comp.view === "function" || typeof comp === "function")? comp : "div"
+				attrs = params, currentPath = path, lastUpdate = null
 				render = (routeResolver.render || identity).bind(routeResolver)
 				run()
 			}
-			if (payload.view) update({}, payload)
+			if (payload.view || typeof payload === "function") update({}, payload)
 			else {
 				if (payload.onmatch) {
 					Promise.resolve(payload.onmatch(params, path)).then(function(resolved) {

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -32,10 +32,40 @@ o.spec("mount", function() {
 		o(threw).equals(true)
 	})
 
-	o("renders into `root`", function() {
+	o("throws on invalid component", function() {
+		var threw = false
+		try {
+			mount(root, {})
+		} catch (e) {
+			threw = true
+		}
+		o(threw).equals(true)
+	})
+
+	o("renders into `root` (POJO component)", function() {
 		mount(root, {
 			view : function() {
 				return m("div")
+			}
+		})
+
+		o(root.firstChild.nodeName).equals("DIV")
+	})
+
+	o("renders into `root` (class component)", function() {
+		function Cmp(){}
+		Cmp.prototype.view = function(){return m("div")}
+		mount(root, Cmp)
+
+		o(root.firstChild.nodeName).equals("DIV")
+	})
+
+	o("renders into `root` factory (factory component)", function() {
+		mount(root, function(){
+			return {
+				view : function() {
+					return m("div")
+				}
 			}
 		})
 

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -51,11 +51,44 @@ o.spec("route", function() {
 					o(root.firstChild.nodeName).equals("DIV")
 				})
 
-				o("routed mount points can redraw synchronously (#1275)", function() {
+				o("routed mount points can redraw synchronously (POJO component)", function() {
 					var view = o.spy()
 
 					$window.location.href = prefix + "/"
 					route(root, "/", {"/":{view:view}})
+
+					o(view.callCount).equals(1)
+
+					redrawService.redraw()
+
+					o(view.callCount).equals(2)
+
+				})
+
+				o("routed mount points can redraw synchronously (constructible component)", function() {
+					var view = o.spy()
+
+					var Cmp = function(){}
+					Cmp.prototype.view = view
+
+					$window.location.href = prefix + "/"
+					route(root, "/", {"/":Cmp})
+
+					o(view.callCount).equals(1)
+
+					redrawService.redraw()
+
+					o(view.callCount).equals(2)
+
+				})
+
+				o("routed mount points can redraw synchronously (factory component)", function() {
+					var view = o.spy()
+
+					function Cmp() {return {view: view}}
+
+					$window.location.href = prefix + "/"
+					route(root, "/", {"/":Cmp})
 
 					o(view.callCount).equals(1)
 


### PR DESCRIPTION
So, I forgot to relax the component tests in `m.mount()` and `m.route`. TODO:

- [x] tests for `m.mount × (factory + constructible)`
- [x] tests for `m.route × (factory + constructible)`
- [x] add support for `(m.mount + m.route) × (factory + constructible)`