### PR TITLE
Make streams publishable to NPM

### DIFF
--- a/stream/package.json
+++ b/stream/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mithril-stream",
+  "version": "1.0.0",
+  "description": "Streaming data, mithril-style",
+  "main": "stream.js",
+  "directories": {
+    "test": "tests"
+  },
+  "keywords": [ "stream", "reactive", "data" ],
+  "author": "Leo Horie <lhorie@hotmail.com>",
+  "license": "MIT",
+  "repository": "lhorie/mithril.js"
+}


### PR DESCRIPTION
Fixes #1629

Had to guess at a name, `stream` is already taken. Something cooler is probably preferable!