### PR TITLE
Test all component kinds

### DIFF
--- a/api/tests/index.html
+++ b/api/tests/index.html
@@ -13,6 +13,7 @@
 		<script src="../../test-utils/pushStateMock.js"></script>
 		<script src="../../test-utils/xhrMock.js"></script>
 		<script src="../../test-utils/browserMock.js"></script>
+		<script src="../../test-utils/component.js"></script>
 
 		<script src="../../promise/promise.js"></script>
 		<script src="../../render/vnode.js"></script>

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -33,7 +33,7 @@ o.spec("mount", function() {
 		o(threw).equals(true)
 	})
 
-	;[components[0]].forEach(function(cmp){
+	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create
 
@@ -47,32 +47,12 @@ o.spec("mount", function() {
 				o(threw).equals(true)
 			})
 
-			o("renders into `root` (POJO component)", function() {
+			o("renders into `root`", function() {
 				mount(root, createComponent({
 					view : function() {
 						return m("div")
 					}
 				}))
-
-				o(root.firstChild.nodeName).equals("DIV")
-			})
-
-			o("renders into `root` (class component)", function() {
-				function Cmp(){}
-				Cmp.prototype.view = function(){return m("div")}
-				mount(root, Cmp)
-
-				o(root.firstChild.nodeName).equals("DIV")
-			})
-
-			o("renders into `root` (closure component)", function() {
-				mount(root, function(){
-					return {
-						view : function() {
-							return m("div")
-						}
-					}
-				})
 
 				o(root.firstChild.nodeName).equals("DIV")
 			})

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var o = require("../../ospec/ospec")
+var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 
 var m = require("../../render/hyperscript")
@@ -32,237 +33,243 @@ o.spec("mount", function() {
 		o(threw).equals(true)
 	})
 
-	o("throws on invalid `root` DOM node", function() {
-		var threw = false
-		try {
-			mount(null, {view: function() {}})
-		} catch (e) {
-			threw = true
-		}
-		o(threw).equals(true)
-	})
+	;[components[0]].forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
 
-	o("renders into `root` (POJO component)", function() {
-		mount(root, {
-			view : function() {
-				return m("div")
-			}
-		})
-
-		o(root.firstChild.nodeName).equals("DIV")
-	})
-
-	o("renders into `root` (class component)", function() {
-		function Cmp(){}
-		Cmp.prototype.view = function(){return m("div")}
-		mount(root, Cmp)
-
-		o(root.firstChild.nodeName).equals("DIV")
-	})
-
-	o("renders into `root` (closure component)", function() {
-		mount(root, function(){
-			return {
-				view : function() {
-					return m("div")
+			o("throws on invalid `root` DOM node", function() {
+				var threw = false
+				try {
+					mount(null, {view: function() {}})
+				} catch (e) {
+					threw = true
 				}
-			}
-		})
+				o(threw).equals(true)
+			})
 
-		o(root.firstChild.nodeName).equals("DIV")
-	})
-
-	o("mounting null unmounts", function() {
-		mount(root, {
-			view : function() {
-				return m("div")
-			}
-		})
-
-		mount(root, null)
-
-		o(root.childNodes.length).equals(0)
-	})
-
-	o("redraws on events", function(done) {
-		var onupdate = o.spy()
-		var oninit   = o.spy()
-		var onclick  = o.spy()
-		var e = $window.document.createEvent("MouseEvents")
-
-		e.initEvent("click", true, true)
-
-		mount(root, {
-			view : function() {
-				return m("div", {
-					oninit   : oninit,
-					onupdate : onupdate,
-					onclick  : onclick,
-				})
-			}
-		})
-
-		root.firstChild.dispatchEvent(e)
-
-		o(oninit.callCount).equals(1)
-		o(onupdate.callCount).equals(0)
-
-		o(onclick.callCount).equals(1)
-		o(onclick.this).equals(root.firstChild)
-		o(onclick.args[0].type).equals("click")
-		o(onclick.args[0].target).equals(root.firstChild)
-
-		// Wrapped to give time for the rate-limited redraw to fire
-		setTimeout(function() {
-			o(onupdate.callCount).equals(1)
-
-			done()
-		}, FRAME_BUDGET)
-	})
-
-	o("redraws several mount points on events", function(done, timeout) {
-		timeout(60)
-		
-		var onupdate0 = o.spy()
-		var oninit0   = o.spy()
-		var onclick0  = o.spy()
-		var onupdate1 = o.spy()
-		var oninit1   = o.spy()
-		var onclick1  = o.spy()
-
-		var e = $window.document.createEvent("MouseEvents")
-
-		e.initEvent("click", true, true)
-
-		render(root, [
-			m("#child0"),
-			m("#child1")
-		])
-
-		mount(root.childNodes[0], {
-			view : function() {
-				return m("div", {
-					oninit   : oninit0,
-					onupdate : onupdate0,
-					onclick  : onclick0,
-				})
-			}
-		})
-
-		o(oninit0.callCount).equals(1)
-		o(onupdate0.callCount).equals(0)
-
-		mount(root.childNodes[1], {
-			view : function() {
-				return m("div", {
-					oninit   : oninit1,
-					onupdate : onupdate1,
-					onclick  : onclick1,
-				})
-			}
-		})
-
-		o(oninit1.callCount).equals(1)
-		o(onupdate1.callCount).equals(0)
-
-		root.childNodes[0].firstChild.dispatchEvent(e)
-		o(onclick0.callCount).equals(1)
-		o(onclick0.this).equals(root.childNodes[0].firstChild)
-
-		setTimeout(function() {
-			o(onupdate0.callCount).equals(1)
-			o(onupdate1.callCount).equals(1)
-
-			root.childNodes[1].firstChild.dispatchEvent(e)
-			o(onclick1.callCount).equals(1)
-			o(onclick1.this).equals(root.childNodes[1].firstChild)
-
-			setTimeout(function() {
-				o(onupdate0.callCount).equals(2)
-				o(onupdate1.callCount).equals(2)
-
-				done()
-			}, FRAME_BUDGET)
-		}, FRAME_BUDGET)
-
-	})
-
-	o("event handlers can skip redraw", function(done) {
-		var onupdate = o.spy()
-		var oninit = o.spy()
-		var e = $window.document.createEvent("MouseEvents")
-
-		e.initEvent("click", true, true)
-
-		mount(root, {
-			view: function() {
-				return m("div", {
-					oninit: oninit,
-					onupdate: onupdate,
-					onclick: function(e) {
-						e.redraw = false
+			o("renders into `root` (POJO component)", function() {
+				mount(root, {
+					view : function() {
+						return m("div")
 					}
 				})
-			}
-		})
 
-		root.firstChild.dispatchEvent(e)
+				o(root.firstChild.nodeName).equals("DIV")
+			})
 
-		o(oninit.callCount).equals(1)
+			o("renders into `root` (class component)", function() {
+				function Cmp(){}
+				Cmp.prototype.view = function(){return m("div")}
+				mount(root, Cmp)
 
-		// Wrapped to ensure no redraw fired
-		setTimeout(function() {
-			o(onupdate.callCount).equals(0)
+				o(root.firstChild.nodeName).equals("DIV")
+			})
 
-			done()
-		}, FRAME_BUDGET)
-	})
-
-	o("redraws when the render function is run", function(done) {
-		var onupdate = o.spy()
-		var oninit = o.spy()
-
-		mount(root, {
-			view : function() {
-				return m("div", {
-					oninit: oninit,
-					onupdate: onupdate
+			o("renders into `root` (closure component)", function() {
+				mount(root, function(){
+					return {
+						view : function() {
+							return m("div")
+						}
+					}
 				})
-			}
+
+				o(root.firstChild.nodeName).equals("DIV")
+			})
+
+			o("mounting null unmounts", function() {
+				mount(root, {
+					view : function() {
+						return m("div")
+					}
+				})
+
+				mount(root, null)
+
+				o(root.childNodes.length).equals(0)
+			})
+
+			o("redraws on events", function(done) {
+				var onupdate = o.spy()
+				var oninit   = o.spy()
+				var onclick  = o.spy()
+				var e = $window.document.createEvent("MouseEvents")
+
+				e.initEvent("click", true, true)
+
+				mount(root, {
+					view : function() {
+						return m("div", {
+							oninit   : oninit,
+							onupdate : onupdate,
+							onclick  : onclick,
+						})
+					}
+				})
+
+				root.firstChild.dispatchEvent(e)
+
+				o(oninit.callCount).equals(1)
+				o(onupdate.callCount).equals(0)
+
+				o(onclick.callCount).equals(1)
+				o(onclick.this).equals(root.firstChild)
+				o(onclick.args[0].type).equals("click")
+				o(onclick.args[0].target).equals(root.firstChild)
+
+				// Wrapped to give time for the rate-limited redraw to fire
+				setTimeout(function() {
+					o(onupdate.callCount).equals(1)
+
+					done()
+				}, FRAME_BUDGET)
+			})
+
+			o("redraws several mount points on events", function(done, timeout) {
+				timeout(60)
+				
+				var onupdate0 = o.spy()
+				var oninit0   = o.spy()
+				var onclick0  = o.spy()
+				var onupdate1 = o.spy()
+				var oninit1   = o.spy()
+				var onclick1  = o.spy()
+
+				var e = $window.document.createEvent("MouseEvents")
+
+				e.initEvent("click", true, true)
+
+				render(root, [
+					m("#child0"),
+					m("#child1")
+				])
+
+				mount(root.childNodes[0], {
+					view : function() {
+						return m("div", {
+							oninit   : oninit0,
+							onupdate : onupdate0,
+							onclick  : onclick0,
+						})
+					}
+				})
+
+				o(oninit0.callCount).equals(1)
+				o(onupdate0.callCount).equals(0)
+
+				mount(root.childNodes[1], {
+					view : function() {
+						return m("div", {
+							oninit   : oninit1,
+							onupdate : onupdate1,
+							onclick  : onclick1,
+						})
+					}
+				})
+
+				o(oninit1.callCount).equals(1)
+				o(onupdate1.callCount).equals(0)
+
+				root.childNodes[0].firstChild.dispatchEvent(e)
+				o(onclick0.callCount).equals(1)
+				o(onclick0.this).equals(root.childNodes[0].firstChild)
+
+				setTimeout(function() {
+					o(onupdate0.callCount).equals(1)
+					o(onupdate1.callCount).equals(1)
+
+					root.childNodes[1].firstChild.dispatchEvent(e)
+					o(onclick1.callCount).equals(1)
+					o(onclick1.this).equals(root.childNodes[1].firstChild)
+
+					setTimeout(function() {
+						o(onupdate0.callCount).equals(2)
+						o(onupdate1.callCount).equals(2)
+
+						done()
+					}, FRAME_BUDGET)
+				}, FRAME_BUDGET)
+
+			})
+
+			o("event handlers can skip redraw", function(done) {
+				var onupdate = o.spy()
+				var oninit = o.spy()
+				var e = $window.document.createEvent("MouseEvents")
+
+				e.initEvent("click", true, true)
+
+				mount(root, {
+					view: function() {
+						return m("div", {
+							oninit: oninit,
+							onupdate: onupdate,
+							onclick: function(e) {
+								e.redraw = false
+							}
+						})
+					}
+				})
+
+				root.firstChild.dispatchEvent(e)
+
+				o(oninit.callCount).equals(1)
+
+				// Wrapped to ensure no redraw fired
+				setTimeout(function() {
+					o(onupdate.callCount).equals(0)
+
+					done()
+				}, FRAME_BUDGET)
+			})
+
+			o("redraws when the render function is run", function(done) {
+				var onupdate = o.spy()
+				var oninit = o.spy()
+
+				mount(root, {
+					view : function() {
+						return m("div", {
+							oninit: oninit,
+							onupdate: onupdate
+						})
+					}
+				})
+
+				o(oninit.callCount).equals(1)
+				o(onupdate.callCount).equals(0)
+
+				redrawService.redraw()
+
+				// Wrapped to give time for the rate-limited redraw to fire
+				setTimeout(function() {
+					o(onupdate.callCount).equals(1)
+
+					done()
+				}, FRAME_BUDGET)
+			})
+			
+			o("throttles", function(done, timeout) {
+				timeout(200)
+
+				var i = 0
+				mount(root, {view: function() {i++}})
+				var before = i
+
+				redrawService.redraw()
+				redrawService.redraw()
+				redrawService.redraw()
+				redrawService.redraw()
+
+				var after = i
+
+				setTimeout(function(){
+					o(before).equals(1) // mounts synchronously
+					o(after).equals(1) // throttles rest
+					o(i).equals(2)
+					done()
+				},40)
+			})
 		})
-
-		o(oninit.callCount).equals(1)
-		o(onupdate.callCount).equals(0)
-
-		redrawService.redraw()
-
-		// Wrapped to give time for the rate-limited redraw to fire
-		setTimeout(function() {
-			o(onupdate.callCount).equals(1)
-
-			done()
-		}, FRAME_BUDGET)
-	})
-	
-	o("throttles", function(done, timeout) {
-		timeout(200)
-
-		var i = 0
-		mount(root, {view: function() {i++}})
-		var before = i
-
-		redrawService.redraw()
-		redrawService.redraw()
-		redrawService.redraw()
-		redrawService.redraw()
-
-		var after = i
-
-		setTimeout(function(){
-			o(before).equals(1) // mounts synchronously
-			o(after).equals(1) // throttles rest
-			o(i).equals(2)
-			done()
-		},40)
 	})
 })

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -40,7 +40,7 @@ o.spec("mount", function() {
 			o("throws on invalid `root` DOM node", function() {
 				var threw = false
 				try {
-					mount(null, {view: function() {}})
+					mount(null, createComponent({view: function() {}}))
 				} catch (e) {
 					threw = true
 				}
@@ -48,11 +48,11 @@ o.spec("mount", function() {
 			})
 
 			o("renders into `root` (POJO component)", function() {
-				mount(root, {
+				mount(root, createComponent({
 					view : function() {
 						return m("div")
 					}
-				})
+				}))
 
 				o(root.firstChild.nodeName).equals("DIV")
 			})
@@ -78,11 +78,11 @@ o.spec("mount", function() {
 			})
 
 			o("mounting null unmounts", function() {
-				mount(root, {
+				mount(root, createComponent({
 					view : function() {
 						return m("div")
 					}
-				})
+				}))
 
 				mount(root, null)
 
@@ -97,7 +97,7 @@ o.spec("mount", function() {
 
 				e.initEvent("click", true, true)
 
-				mount(root, {
+				mount(root, createComponent({
 					view : function() {
 						return m("div", {
 							oninit   : oninit,
@@ -105,7 +105,7 @@ o.spec("mount", function() {
 							onclick  : onclick,
 						})
 					}
-				})
+				}))
 
 				root.firstChild.dispatchEvent(e)
 
@@ -144,7 +144,7 @@ o.spec("mount", function() {
 					m("#child1")
 				])
 
-				mount(root.childNodes[0], {
+				mount(root.childNodes[0], createComponent({
 					view : function() {
 						return m("div", {
 							oninit   : oninit0,
@@ -152,12 +152,12 @@ o.spec("mount", function() {
 							onclick  : onclick0,
 						})
 					}
-				})
+				}))
 
 				o(oninit0.callCount).equals(1)
 				o(onupdate0.callCount).equals(0)
 
-				mount(root.childNodes[1], {
+				mount(root.childNodes[1], createComponent({
 					view : function() {
 						return m("div", {
 							oninit   : oninit1,
@@ -165,7 +165,7 @@ o.spec("mount", function() {
 							onclick  : onclick1,
 						})
 					}
-				})
+				}))
 
 				o(oninit1.callCount).equals(1)
 				o(onupdate1.callCount).equals(0)
@@ -199,7 +199,7 @@ o.spec("mount", function() {
 
 				e.initEvent("click", true, true)
 
-				mount(root, {
+				mount(root, createComponent({
 					view: function() {
 						return m("div", {
 							oninit: oninit,
@@ -209,7 +209,7 @@ o.spec("mount", function() {
 							}
 						})
 					}
-				})
+				}))
 
 				root.firstChild.dispatchEvent(e)
 
@@ -227,14 +227,14 @@ o.spec("mount", function() {
 				var onupdate = o.spy()
 				var oninit = o.spy()
 
-				mount(root, {
+				mount(root, createComponent({
 					view : function() {
 						return m("div", {
 							oninit: oninit,
 							onupdate: onupdate
 						})
 					}
-				})
+				}))
 
 				o(oninit.callCount).equals(1)
 				o(onupdate.callCount).equals(0)
@@ -253,7 +253,7 @@ o.spec("mount", function() {
 				timeout(200)
 
 				var i = 0
-				mount(root, {view: function() {i++}})
+				mount(root, createComponent({view: function() {i++}}))
 				var before = i
 
 				redrawService.redraw()

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -60,7 +60,7 @@ o.spec("mount", function() {
 		o(root.firstChild.nodeName).equals("DIV")
 	})
 
-	o("renders into `root` factory (factory component)", function() {
+	o("renders into `root` (closure component)", function() {
 		mount(root, function(){
 			return {
 				view : function() {

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -22,20 +22,20 @@ o.spec("mount", function() {
 		render = coreRenderer($window).render
 	})
 
-	o("throws on invalid `root` DOM node", function() {
+	o("throws on invalid component", function() {
 		var threw = false
 		try {
-			mount(null, {view: function() {}})
+			mount(root, {})
 		} catch (e) {
 			threw = true
 		}
 		o(threw).equals(true)
 	})
 
-	o("throws on invalid component", function() {
+	o("throws on invalid `root` DOM node", function() {
 		var threw = false
 		try {
-			mount(root, {})
+			mount(null, {view: function() {}})
 		} catch (e) {
 			threw = true
 		}

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -82,7 +82,7 @@ o.spec("route", function() {
 
 				})
 
-				o("routed mount points can redraw synchronously (factory component)", function() {
+				o("routed mount points can redraw synchronously (closure component)", function() {
 					var view = o.spy()
 
 					function Cmp() {return {view: view}}

--- a/render/tests/index.html
+++ b/render/tests/index.html
@@ -8,6 +8,7 @@
 		<script src="../../ospec/ospec.js"></script>
 		<script src="../../test-utils/callAsync.js"></script>
 		<script src="../../test-utils/domMock.js"></script>
+		<script src="../../test-utils/component.js"></script>
 
 		<script src="../../render/vnode.js"></script>
 		<script src="../../render/trust.js"></script>

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -658,7 +658,7 @@ o.spec("component", function() {
 				})
 			})
 			o.spec("state", function() {
-				o("copies state", function() {
+				o("initializes state", function() {
 					var called = 0
 					var data = {a: 1}
 					var component = {
@@ -672,15 +672,10 @@ o.spec("component", function() {
 					render(root, [{tag: component}])
 
 					function init(vnode) {
-						o(vnode.state.data).deepEquals(data)
 						o(vnode.state.data).equals(data)
-
-						//inherits state via prototype
-						component.x = 1
-						o(vnode.state.x).equals(1)
 					}
 				})
-				o("state copy is shallow", function() {
+				o('state "copy" is shallow', function() {
 					var called = 0
 					var body = {a: 1}
 					var data = [body]
@@ -702,7 +697,32 @@ o.spec("component", function() {
 			})
 		})
 	})
-	o.spec("Alternative ways to specify components", function() {
+	o.spec("Tests specific to certain component kinds", function() {
+
+		o.spec("POJO state", function() {
+			o("copies state", function() {
+				var called = 0
+				var data = {a: 1}
+				var component = {
+					data: data,
+					oninit: init,
+					view: function() {
+						return ""
+					}
+				}
+
+				render(root, [{tag: component}])
+
+				function init(vnode) {
+					o(vnode.state.data).equals(data)
+
+					//inherits state via prototype
+					component.x = 1
+					o(vnode.state.x).equals(1)
+				}
+			})
+		})
+
 		o("Classes can be used as components", function() {
 			function MyComponent(vnode){
 				o(vnode.state).equals(null)
@@ -769,7 +789,7 @@ o.spec("component", function() {
 			o(proto.onbeforeremove.args.length).equals(1)
 			o(proto.onremove.args.length).equals(1)
 		})
-		o("Factory functions can be used as components", function() {
+		o("Closure functions can be used as components", function() {
 			var state, context
 			function component(vnode) {
 				o(vnode.state).equals(null)

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -397,7 +397,7 @@ o.spec("component", function() {
 				o("calls oninit before view", function() {
 					var viewCalled = false
 
-					render(root, {
+					render(root, createComponent({
 						tag: {
 							view: function() {
 								viewCalled = true
@@ -407,7 +407,7 @@ o.spec("component", function() {
 								o(viewCalled).equals(false)
 							},
 						}
-					})
+					}))
 				})
 				o("does not calls oninit on redraw", function() {
 					var init = o.spy()
@@ -661,13 +661,13 @@ o.spec("component", function() {
 				o("initializes state", function() {
 					var called = 0
 					var data = {a: 1}
-					var component = {
+					var component = createComponent({
 						data: data,
 						oninit: init,
 						view: function() {
 							return ""
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 
@@ -679,13 +679,13 @@ o.spec("component", function() {
 					var called = 0
 					var body = {a: 1}
 					var data = [body]
-					var component = {
+					var component = createComponent({
 						data: data,
 						oninit: init,
 						view: function() {
 							return ""
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -14,7 +14,7 @@ o.spec("component", function() {
 		render = vdom($window).render
 	})
 
-	;[components[0]].forEach(function(cmp){
+	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create
 

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -20,11 +20,11 @@ o.spec("component", function() {
 
 			o.spec("basics", function() {
 				o("works", function() {
-					var component = {
+					var component = createComponent({
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						}
-					}
+					})
 					var node = {tag: component}
 
 					render(root, [node])
@@ -34,11 +34,11 @@ o.spec("component", function() {
 					o(root.firstChild.firstChild.nodeValue).equals("b")
 				})
 				o("receives arguments", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return {tag: "div", attrs: vnode.attrs, text: vnode.text}
 						}
-					}
+					})
 					var node = {tag: component, attrs: {id: "a"}, text: "b"}
 
 					render(root, [node])
@@ -48,11 +48,11 @@ o.spec("component", function() {
 					o(root.firstChild.firstChild.nodeValue).equals("b")
 				})
 				o("updates", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return {tag: "div", attrs: vnode.attrs, text: vnode.text}
 						}
-					}
+					})
 					render(root, [{tag: component, attrs: {id: "a"}, text: "b"}])
 					render(root, [{tag: component, attrs: {id: "c"}, text: "d"}])
 
@@ -62,11 +62,11 @@ o.spec("component", function() {
 				})
 				o("updates root from null", function() {
 					var visible = false
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return visible ? {tag: "div"} : null
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					visible = true
 					render(root, [{tag: component}])
@@ -75,11 +75,11 @@ o.spec("component", function() {
 				})
 				o("updates root from primitive", function() {
 					var visible = false
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return visible ? {tag: "div"} : false
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					visible = true
 					render(root, [{tag: component}])
@@ -88,11 +88,11 @@ o.spec("component", function() {
 				})
 				o("updates root to null", function() {
 					var visible = true
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return visible ? {tag: "div"} : null
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					visible = false
 					render(root, [{tag: component}])
@@ -101,11 +101,11 @@ o.spec("component", function() {
 				})
 				o("updates root to primitive", function() {
 					var visible = true
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return visible ? {tag: "div"} : false
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					visible = false
 					render(root, [{tag: component}])
@@ -113,22 +113,22 @@ o.spec("component", function() {
 					o(root.firstChild.nodeValue).equals("")
 				})
 				o("updates root from null to null", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return null
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					render(root, [{tag: component}])
 
 					o(root.childNodes.length).equals(0)
 				})
 				o("removes", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return {tag: "div"}
 						}
-					}
+					})
 					var div = {tag: "div", key: 2}
 					render(root, [{tag: component, key: 1}, div])
 					render(root, [{tag: "div", key: 2}])
@@ -137,21 +137,21 @@ o.spec("component", function() {
 					o(root.firstChild).equals(div.dom)
 				})
 				o("svg works when creating across component boundary", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return {tag: "g"}
 						}
-					}
+					})
 					render(root, [{tag: "svg", children: [{tag: component}]}])
 
 					o(root.firstChild.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
 				})
 				o("svg works when updating across component boundary", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return {tag: "g"}
 						}
-					}
+					})
 					render(root, [{tag: "svg", children: [{tag: component}]}])
 					render(root, [{tag: "svg", children: [{tag: component}]}])
 
@@ -160,14 +160,14 @@ o.spec("component", function() {
 			})
 			o.spec("return value", function() {
 				o("can return fragments", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return [
 								{tag: "label"},
 								{tag: "input"},
 							]
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.childNodes.length).equals(2)
@@ -175,98 +175,98 @@ o.spec("component", function() {
 					o(root.childNodes[1].nodeName).equals("INPUT")
 				})
 				o("can return string", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return "a"
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.firstChild.nodeType).equals(3)
 					o(root.firstChild.nodeValue).equals("a")
 				})
 				o("can return falsy string", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return ""
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.firstChild.nodeType).equals(3)
 					o(root.firstChild.nodeValue).equals("")
 				})
 				o("can return number", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return 1
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.firstChild.nodeType).equals(3)
 					o(root.firstChild.nodeValue).equals("1")
 				})
 				o("can return falsy number", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return 0
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.firstChild.nodeType).equals(3)
 					o(root.firstChild.nodeValue).equals("0")
 				})
 				o("can return boolean", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return true
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.firstChild.nodeType).equals(3)
 					o(root.firstChild.nodeValue).equals("true")
 				})
 				o("can return falsy boolean", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return false
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.firstChild.nodeType).equals(3)
 					o(root.firstChild.nodeValue).equals("")
 				})
 				o("can return null", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return null
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.childNodes.length).equals(0)
 				})
 				o("can return undefined", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return undefined
 						}
-					}
+					})
 					render(root, [{tag: component}])
 
 					o(root.childNodes.length).equals(0)
 				})
 				o("throws a custom error if it returns itself", function() {
 					// A view that returns its vnode would otherwise trigger an infinite loop
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return vnode
 						}
-					}
+					})
 					try {
 						render(root, [{tag: component}])
 					}
@@ -277,14 +277,14 @@ o.spec("component", function() {
 					}
 				})
 				o("can update when returning fragments", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return [
 								{tag: "label"},
 								{tag: "input"},
 							]
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					render(root, [{tag: component}])
 
@@ -293,11 +293,11 @@ o.spec("component", function() {
 					o(root.childNodes[1].nodeName).equals("INPUT")
 				})
 				o("can update when returning primitive", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return "a"
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					render(root, [{tag: component}])
 
@@ -305,25 +305,25 @@ o.spec("component", function() {
 					o(root.firstChild.nodeValue).equals("a")
 				})
 				o("can update when returning null", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return null
 						}
-					}
+					})
 					render(root, [{tag: component}])
 					render(root, [{tag: component}])
 
 					o(root.childNodes.length).equals(0)
 				})
 				o("can remove when returning fragments", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return [
 								{tag: "label"},
 								{tag: "input"},
 							]
 						}
-					}
+					})
 					var div = {tag: "div", key: 2}
 					render(root, [{tag: component, key: 1}, div])
 
@@ -333,11 +333,11 @@ o.spec("component", function() {
 					o(root.firstChild).equals(div.dom)
 				})
 				o("can remove when returning primitive", function() {
-					var component = {
+					var component = createComponent({
 						view: function(vnode) {
 							return "a"
 						}
-					}
+					})
 					var div = {tag: "div", key: 2}
 					render(root, [{tag: component, key: 1}, div])
 
@@ -350,7 +350,7 @@ o.spec("component", function() {
 			o.spec("lifecycle", function() {
 				o("calls oninit", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						oninit: function(vnode) {
 							called++
 
@@ -361,7 +361,7 @@ o.spec("component", function() {
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						}
-					}
+					})
 					var node = {tag: component}
 
 					render(root, [node])
@@ -373,7 +373,7 @@ o.spec("component", function() {
 				})
 				o("calls oninit when returning fragment", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						oninit: function(vnode) {
 							called++
 
@@ -384,7 +384,7 @@ o.spec("component", function() {
 						view: function() {
 							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
 						}
-					}
+					})
 					var node = {tag: component}
 
 					render(root, [node])
@@ -411,12 +411,12 @@ o.spec("component", function() {
 				})
 				o("does not calls oninit on redraw", function() {
 					var init = o.spy()
-					var component = {
+					var component = createComponent({
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						},
 						oninit: init,
-					}
+					})
 
 					function view() {
 						return {tag: component}
@@ -429,7 +429,7 @@ o.spec("component", function() {
 				})
 				o("calls oncreate", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						oncreate: function(vnode) {
 							called++
 
@@ -440,7 +440,7 @@ o.spec("component", function() {
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						}
-					}
+					})
 					var node = {tag: component}
 
 					render(root, [node])
@@ -452,12 +452,12 @@ o.spec("component", function() {
 				})
 				o("does not calls oncreate on redraw", function() {
 					var create = o.spy()
-					var component = {
+					var component = createComponent({
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						},
 						oncreate: create,
-					}
+					})
 
 					function view() {
 						return {tag: component}
@@ -470,7 +470,7 @@ o.spec("component", function() {
 				})
 				o("calls oncreate when returning fragment", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						oncreate: function(vnode) {
 							called++
 
@@ -481,7 +481,7 @@ o.spec("component", function() {
 						view: function() {
 							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
 						}
-					}
+					})
 					var node = {tag: component}
 
 					render(root, [node])
@@ -493,7 +493,7 @@ o.spec("component", function() {
 				})
 				o("calls onupdate", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						onupdate: function(vnode) {
 							called++
 
@@ -504,7 +504,7 @@ o.spec("component", function() {
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 
@@ -519,7 +519,7 @@ o.spec("component", function() {
 				})
 				o("calls onupdate when returning fragment", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						onupdate: function(vnode) {
 							called++
 
@@ -530,7 +530,7 @@ o.spec("component", function() {
 						view: function() {
 							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 
@@ -545,7 +545,7 @@ o.spec("component", function() {
 				})
 				o("calls onremove", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						onremove: function(vnode) {
 							called++
 
@@ -556,7 +556,7 @@ o.spec("component", function() {
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 
@@ -569,7 +569,7 @@ o.spec("component", function() {
 				})
 				o("calls onremove when returning fragment", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						onremove: function(vnode) {
 							called++
 
@@ -580,7 +580,7 @@ o.spec("component", function() {
 						view: function() {
 							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 
@@ -593,7 +593,7 @@ o.spec("component", function() {
 				})
 				o("calls onbeforeremove", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						onbeforeremove: function(vnode) {
 							called++
 
@@ -604,7 +604,7 @@ o.spec("component", function() {
 						view: function() {
 							return {tag: "div", attrs: {id: "a"}, text: "b"}
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 
@@ -617,7 +617,7 @@ o.spec("component", function() {
 				})
 				o("calls onbeforeremove when returning fragment", function() {
 					var called = 0
-					var component = {
+					var component = createComponent({
 						onbeforeremove: function(vnode) {
 							called++
 
@@ -628,7 +628,7 @@ o.spec("component", function() {
 						view: function() {
 							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
 						}
-					}
+					})
 
 					render(root, [{tag: component}])
 
@@ -640,12 +640,12 @@ o.spec("component", function() {
 					o(root.childNodes.length).equals(0)
 				})
 				o("does not recycle when there's an onupdate", function() {
-					var component = {
+					var component = createComponent({
 						onupdate: function() {},
 						view: function() {
 							return {tag: "div"}
 						}
-					}
+					})
 					var update = o.spy()
 					var vnode = {tag: component, key: 1}
 					var updated = {tag: component, key: 1}
@@ -661,13 +661,13 @@ o.spec("component", function() {
 				o("initializes state", function() {
 					var called = 0
 					var data = {a: 1}
-					var component = createComponent({
+					var component = createComponent(createComponent({
 						data: data,
 						oninit: init,
 						view: function() {
 							return ""
 						}
-					})
+					}))
 
 					render(root, [{tag: component}])
 
@@ -679,13 +679,13 @@ o.spec("component", function() {
 					var called = 0
 					var body = {a: 1}
 					var data = [body]
-					var component = createComponent({
+					var component = createComponent(createComponent({
 						data: data,
 						oninit: init,
 						view: function() {
 							return ""
 						}
-					})
+					}))
 
 					render(root, [{tag: component}])
 

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var o = require("../../ospec/ospec")
+var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 var vdom = require("../../render/render")
 
@@ -13,689 +14,695 @@ o.spec("component", function() {
 		render = vdom($window).render
 	})
 
-	o.spec("basics", function() {
-		o("works", function() {
-			var component = {
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				}
-			}
-			var node = {tag: component}
+	;[components[0]].forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
 
-			render(root, [node])
+			o.spec("basics", function() {
+				o("works", function() {
+					var component = {
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						}
+					}
+					var node = {tag: component}
 
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("receives arguments", function() {
-			var component = {
-				view: function(vnode) {
-					return {tag: "div", attrs: vnode.attrs, text: vnode.text}
-				}
-			}
-			var node = {tag: component, attrs: {id: "a"}, text: "b"}
+					render(root, [node])
 
-			render(root, [node])
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("receives arguments", function() {
+					var component = {
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: vnode.text}
+						}
+					}
+					var node = {tag: component, attrs: {id: "a"}, text: "b"}
 
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("updates", function() {
-			var component = {
-				view: function(vnode) {
-					return {tag: "div", attrs: vnode.attrs, text: vnode.text}
-				}
-			}
-			render(root, [{tag: component, attrs: {id: "a"}, text: "b"}])
-			render(root, [{tag: component, attrs: {id: "c"}, text: "d"}])
+					render(root, [node])
 
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("c")
-			o(root.firstChild.firstChild.nodeValue).equals("d")
-		})
-		o("updates root from null", function() {
-			var visible = false
-			var component = {
-				view: function(vnode) {
-					return visible ? {tag: "div"} : null
-				}
-			}
-			render(root, [{tag: component}])
-			visible = true
-			render(root, [{tag: component}])
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("updates", function() {
+					var component = {
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: vnode.text}
+						}
+					}
+					render(root, [{tag: component, attrs: {id: "a"}, text: "b"}])
+					render(root, [{tag: component, attrs: {id: "c"}, text: "d"}])
 
-			o(root.firstChild.nodeName).equals("DIV")
-		})
-		o("updates root from primitive", function() {
-			var visible = false
-			var component = {
-				view: function(vnode) {
-					return visible ? {tag: "div"} : false
-				}
-			}
-			render(root, [{tag: component}])
-			visible = true
-			render(root, [{tag: component}])
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("c")
+					o(root.firstChild.firstChild.nodeValue).equals("d")
+				})
+				o("updates root from null", function() {
+					var visible = false
+					var component = {
+						view: function(vnode) {
+							return visible ? {tag: "div"} : null
+						}
+					}
+					render(root, [{tag: component}])
+					visible = true
+					render(root, [{tag: component}])
 
-			o(root.firstChild.nodeName).equals("DIV")
-		})
-		o("updates root to null", function() {
-			var visible = true
-			var component = {
-				view: function(vnode) {
-					return visible ? {tag: "div"} : null
-				}
-			}
-			render(root, [{tag: component}])
-			visible = false
-			render(root, [{tag: component}])
+					o(root.firstChild.nodeName).equals("DIV")
+				})
+				o("updates root from primitive", function() {
+					var visible = false
+					var component = {
+						view: function(vnode) {
+							return visible ? {tag: "div"} : false
+						}
+					}
+					render(root, [{tag: component}])
+					visible = true
+					render(root, [{tag: component}])
 
-			o(root.childNodes.length).equals(0)
-		})
-		o("updates root to primitive", function() {
-			var visible = true
-			var component = {
-				view: function(vnode) {
-					return visible ? {tag: "div"} : false
-				}
-			}
-			render(root, [{tag: component}])
-			visible = false
-			render(root, [{tag: component}])
+					o(root.firstChild.nodeName).equals("DIV")
+				})
+				o("updates root to null", function() {
+					var visible = true
+					var component = {
+						view: function(vnode) {
+							return visible ? {tag: "div"} : null
+						}
+					}
+					render(root, [{tag: component}])
+					visible = false
+					render(root, [{tag: component}])
 
-			o(root.firstChild.nodeValue).equals("")
-		})
-		o("updates root from null to null", function() {
-			var component = {
-				view: function(vnode) {
-					return null
-				}
-			}
-			render(root, [{tag: component}])
-			render(root, [{tag: component}])
-
-			o(root.childNodes.length).equals(0)
-		})
-		o("removes", function() {
-			var component = {
-				view: function(vnode) {
-					return {tag: "div"}
-				}
-			}
-			var div = {tag: "div", key: 2}
-			render(root, [{tag: component, key: 1}, div])
-			render(root, [{tag: "div", key: 2}])
-
-			o(root.childNodes.length).equals(1)
-			o(root.firstChild).equals(div.dom)
-		})
-		o("svg works when creating across component boundary", function() {
-			var component = {
-				view: function(vnode) {
-					return {tag: "g"}
-				}
-			}
-			render(root, [{tag: "svg", children: [{tag: component}]}])
-
-			o(root.firstChild.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
-		})
-		o("svg works when updating across component boundary", function() {
-			var component = {
-				view: function(vnode) {
-					return {tag: "g"}
-				}
-			}
-			render(root, [{tag: "svg", children: [{tag: component}]}])
-			render(root, [{tag: "svg", children: [{tag: component}]}])
-
-			o(root.firstChild.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
-		})
-	})
-	o.spec("return value", function() {
-		o("can return fragments", function() {
-			var component = {
-				view: function(vnode) {
-					return [
-						{tag: "label"},
-						{tag: "input"},
-					]
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.childNodes.length).equals(2)
-			o(root.childNodes[0].nodeName).equals("LABEL")
-			o(root.childNodes[1].nodeName).equals("INPUT")
-		})
-		o("can return string", function() {
-			var component = {
-				view: function(vnode) {
-					return "a"
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("a")
-		})
-		o("can return falsy string", function() {
-			var component = {
-				view: function(vnode) {
-					return ""
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("")
-		})
-		o("can return number", function() {
-			var component = {
-				view: function(vnode) {
-					return 1
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("1")
-		})
-		o("can return falsy number", function() {
-			var component = {
-				view: function(vnode) {
-					return 0
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("0")
-		})
-		o("can return boolean", function() {
-			var component = {
-				view: function(vnode) {
-					return true
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("true")
-		})
-		o("can return falsy boolean", function() {
-			var component = {
-				view: function(vnode) {
-					return false
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("")
-		})
-		o("can return null", function() {
-			var component = {
-				view: function(vnode) {
-					return null
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.childNodes.length).equals(0)
-		})
-		o("can return undefined", function() {
-			var component = {
-				view: function(vnode) {
-					return undefined
-				}
-			}
-			render(root, [{tag: component}])
-
-			o(root.childNodes.length).equals(0)
-		})
-		o("throws a custom error if it returns itself", function() {
-			// A view that returns its vnode would otherwise trigger an infinite loop
-			var component = {
-				view: function(vnode) {
-					return vnode
-				}
-			}
-			try {
-				render(root, [{tag: component}])
-			}
-			catch (e) {
-				o(e instanceof Error).equals(true)
-				// Call stack exception is a RangeError
-				o(e instanceof RangeError).equals(false)
-			}
-		})
-		o("can update when returning fragments", function() {
-			var component = {
-				view: function(vnode) {
-					return [
-						{tag: "label"},
-						{tag: "input"},
-					]
-				}
-			}
-			render(root, [{tag: component}])
-			render(root, [{tag: component}])
-
-			o(root.childNodes.length).equals(2)
-			o(root.childNodes[0].nodeName).equals("LABEL")
-			o(root.childNodes[1].nodeName).equals("INPUT")
-		})
-		o("can update when returning primitive", function() {
-			var component = {
-				view: function(vnode) {
-					return "a"
-				}
-			}
-			render(root, [{tag: component}])
-			render(root, [{tag: component}])
-
-			o(root.firstChild.nodeType).equals(3)
-			o(root.firstChild.nodeValue).equals("a")
-		})
-		o("can update when returning null", function() {
-			var component = {
-				view: function(vnode) {
-					return null
-				}
-			}
-			render(root, [{tag: component}])
-			render(root, [{tag: component}])
-
-			o(root.childNodes.length).equals(0)
-		})
-		o("can remove when returning fragments", function() {
-			var component = {
-				view: function(vnode) {
-					return [
-						{tag: "label"},
-						{tag: "input"},
-					]
-				}
-			}
-			var div = {tag: "div", key: 2}
-			render(root, [{tag: component, key: 1}, div])
-
-			render(root, [{tag: "div", key: 2}])
-
-			o(root.childNodes.length).equals(1)
-			o(root.firstChild).equals(div.dom)
-		})
-		o("can remove when returning primitive", function() {
-			var component = {
-				view: function(vnode) {
-					return "a"
-				}
-			}
-			var div = {tag: "div", key: 2}
-			render(root, [{tag: component, key: 1}, div])
-
-			render(root, [{tag: "div", key: 2}])
-
-			o(root.childNodes.length).equals(1)
-			o(root.firstChild).equals(div.dom)
-		})
-	})
-	o.spec("lifecycle", function() {
-		o("calls oninit", function() {
-			var called = 0
-			var component = {
-				oninit: function(vnode) {
-					called++
-
-					o(vnode.tag).equals(component)
-					o(vnode.dom).equals(undefined)
 					o(root.childNodes.length).equals(0)
-				},
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				}
-			}
-			var node = {tag: component}
+				})
+				o("updates root to primitive", function() {
+					var visible = true
+					var component = {
+						view: function(vnode) {
+							return visible ? {tag: "div"} : false
+						}
+					}
+					render(root, [{tag: component}])
+					visible = false
+					render(root, [{tag: component}])
 
-			render(root, [node])
+					o(root.firstChild.nodeValue).equals("")
+				})
+				o("updates root from null to null", function() {
+					var component = {
+						view: function(vnode) {
+							return null
+						}
+					}
+					render(root, [{tag: component}])
+					render(root, [{tag: component}])
 
-			o(called).equals(1)
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("calls oninit when returning fragment", function() {
-			var called = 0
-			var component = {
-				oninit: function(vnode) {
-					called++
-
-					o(vnode.tag).equals(component)
-					o(vnode.dom).equals(undefined)
 					o(root.childNodes.length).equals(0)
-				},
-				view: function() {
-					return [{tag: "div", attrs: {id: "a"}, text: "b"}]
-				}
-			}
-			var node = {tag: component}
+				})
+				o("removes", function() {
+					var component = {
+						view: function(vnode) {
+							return {tag: "div"}
+						}
+					}
+					var div = {tag: "div", key: 2}
+					render(root, [{tag: component, key: 1}, div])
+					render(root, [{tag: "div", key: 2}])
 
-			render(root, [node])
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild).equals(div.dom)
+				})
+				o("svg works when creating across component boundary", function() {
+					var component = {
+						view: function(vnode) {
+							return {tag: "g"}
+						}
+					}
+					render(root, [{tag: "svg", children: [{tag: component}]}])
 
-			o(called).equals(1)
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("calls oninit before view", function() {
-			var viewCalled = false
+					o(root.firstChild.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
+				})
+				o("svg works when updating across component boundary", function() {
+					var component = {
+						view: function(vnode) {
+							return {tag: "g"}
+						}
+					}
+					render(root, [{tag: "svg", children: [{tag: component}]}])
+					render(root, [{tag: "svg", children: [{tag: component}]}])
 
-			render(root, {
-				tag: {
-					view: function() {
-						viewCalled = true
-						return [{tag: "div", attrs: {id: "a"}, text: "b"}]
-					},
-					oninit: function(vnode) {
-						o(viewCalled).equals(false)
-					},
-				}
+					o(root.firstChild.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
+				})
+			})
+			o.spec("return value", function() {
+				o("can return fragments", function() {
+					var component = {
+						view: function(vnode) {
+							return [
+								{tag: "label"},
+								{tag: "input"},
+							]
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("LABEL")
+					o(root.childNodes[1].nodeName).equals("INPUT")
+				})
+				o("can return string", function() {
+					var component = {
+						view: function(vnode) {
+							return "a"
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.firstChild.nodeType).equals(3)
+					o(root.firstChild.nodeValue).equals("a")
+				})
+				o("can return falsy string", function() {
+					var component = {
+						view: function(vnode) {
+							return ""
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.firstChild.nodeType).equals(3)
+					o(root.firstChild.nodeValue).equals("")
+				})
+				o("can return number", function() {
+					var component = {
+						view: function(vnode) {
+							return 1
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.firstChild.nodeType).equals(3)
+					o(root.firstChild.nodeValue).equals("1")
+				})
+				o("can return falsy number", function() {
+					var component = {
+						view: function(vnode) {
+							return 0
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.firstChild.nodeType).equals(3)
+					o(root.firstChild.nodeValue).equals("0")
+				})
+				o("can return boolean", function() {
+					var component = {
+						view: function(vnode) {
+							return true
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.firstChild.nodeType).equals(3)
+					o(root.firstChild.nodeValue).equals("true")
+				})
+				o("can return falsy boolean", function() {
+					var component = {
+						view: function(vnode) {
+							return false
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.firstChild.nodeType).equals(3)
+					o(root.firstChild.nodeValue).equals("")
+				})
+				o("can return null", function() {
+					var component = {
+						view: function(vnode) {
+							return null
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.childNodes.length).equals(0)
+				})
+				o("can return undefined", function() {
+					var component = {
+						view: function(vnode) {
+							return undefined
+						}
+					}
+					render(root, [{tag: component}])
+
+					o(root.childNodes.length).equals(0)
+				})
+				o("throws a custom error if it returns itself", function() {
+					// A view that returns its vnode would otherwise trigger an infinite loop
+					var component = {
+						view: function(vnode) {
+							return vnode
+						}
+					}
+					try {
+						render(root, [{tag: component}])
+					}
+					catch (e) {
+						o(e instanceof Error).equals(true)
+						// Call stack exception is a RangeError
+						o(e instanceof RangeError).equals(false)
+					}
+				})
+				o("can update when returning fragments", function() {
+					var component = {
+						view: function(vnode) {
+							return [
+								{tag: "label"},
+								{tag: "input"},
+							]
+						}
+					}
+					render(root, [{tag: component}])
+					render(root, [{tag: component}])
+
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("LABEL")
+					o(root.childNodes[1].nodeName).equals("INPUT")
+				})
+				o("can update when returning primitive", function() {
+					var component = {
+						view: function(vnode) {
+							return "a"
+						}
+					}
+					render(root, [{tag: component}])
+					render(root, [{tag: component}])
+
+					o(root.firstChild.nodeType).equals(3)
+					o(root.firstChild.nodeValue).equals("a")
+				})
+				o("can update when returning null", function() {
+					var component = {
+						view: function(vnode) {
+							return null
+						}
+					}
+					render(root, [{tag: component}])
+					render(root, [{tag: component}])
+
+					o(root.childNodes.length).equals(0)
+				})
+				o("can remove when returning fragments", function() {
+					var component = {
+						view: function(vnode) {
+							return [
+								{tag: "label"},
+								{tag: "input"},
+							]
+						}
+					}
+					var div = {tag: "div", key: 2}
+					render(root, [{tag: component, key: 1}, div])
+
+					render(root, [{tag: "div", key: 2}])
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild).equals(div.dom)
+				})
+				o("can remove when returning primitive", function() {
+					var component = {
+						view: function(vnode) {
+							return "a"
+						}
+					}
+					var div = {tag: "div", key: 2}
+					render(root, [{tag: component, key: 1}, div])
+
+					render(root, [{tag: "div", key: 2}])
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild).equals(div.dom)
+				})
+			})
+			o.spec("lifecycle", function() {
+				o("calls oninit", function() {
+					var called = 0
+					var component = {
+						oninit: function(vnode) {
+							called++
+
+							o(vnode.tag).equals(component)
+							o(vnode.dom).equals(undefined)
+							o(root.childNodes.length).equals(0)
+						},
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						}
+					}
+					var node = {tag: component}
+
+					render(root, [node])
+
+					o(called).equals(1)
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("calls oninit when returning fragment", function() {
+					var called = 0
+					var component = {
+						oninit: function(vnode) {
+							called++
+
+							o(vnode.tag).equals(component)
+							o(vnode.dom).equals(undefined)
+							o(root.childNodes.length).equals(0)
+						},
+						view: function() {
+							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
+						}
+					}
+					var node = {tag: component}
+
+					render(root, [node])
+
+					o(called).equals(1)
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("calls oninit before view", function() {
+					var viewCalled = false
+
+					render(root, {
+						tag: {
+							view: function() {
+								viewCalled = true
+								return [{tag: "div", attrs: {id: "a"}, text: "b"}]
+							},
+							oninit: function(vnode) {
+								o(viewCalled).equals(false)
+							},
+						}
+					})
+				})
+				o("does not calls oninit on redraw", function() {
+					var init = o.spy()
+					var component = {
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						},
+						oninit: init,
+					}
+
+					function view() {
+						return {tag: component}
+					}
+
+					render(root, view())
+					render(root, view())
+
+					o(init.callCount).equals(1)
+				})
+				o("calls oncreate", function() {
+					var called = 0
+					var component = {
+						oncreate: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						}
+					}
+					var node = {tag: component}
+
+					render(root, [node])
+
+					o(called).equals(1)
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("does not calls oncreate on redraw", function() {
+					var create = o.spy()
+					var component = {
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						},
+						oncreate: create,
+					}
+
+					function view() {
+						return {tag: component}
+					}
+
+					render(root, view())
+					render(root, view())
+
+					o(create.callCount).equals(1)
+				})
+				o("calls oncreate when returning fragment", function() {
+					var called = 0
+					var component = {
+						oncreate: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
+						}
+					}
+					var node = {tag: component}
+
+					render(root, [node])
+
+					o(called).equals(1)
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("calls onupdate", function() {
+					var called = 0
+					var component = {
+						onupdate: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					o(called).equals(0)
+
+					render(root, [{tag: component}])
+
+					o(called).equals(1)
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("calls onupdate when returning fragment", function() {
+					var called = 0
+					var component = {
+						onupdate: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					o(called).equals(0)
+
+					render(root, [{tag: component}])
+
+					o(called).equals(1)
+					o(root.firstChild.nodeName).equals("DIV")
+					o(root.firstChild.attributes["id"].nodeValue).equals("a")
+					o(root.firstChild.firstChild.nodeValue).equals("b")
+				})
+				o("calls onremove", function() {
+					var called = 0
+					var component = {
+						onremove: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					o(called).equals(0)
+
+					render(root, [])
+
+					o(called).equals(1)
+					o(root.childNodes.length).equals(0)
+				})
+				o("calls onremove when returning fragment", function() {
+					var called = 0
+					var component = {
+						onremove: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					o(called).equals(0)
+
+					render(root, [])
+
+					o(called).equals(1)
+					o(root.childNodes.length).equals(0)
+				})
+				o("calls onbeforeremove", function() {
+					var called = 0
+					var component = {
+						onbeforeremove: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return {tag: "div", attrs: {id: "a"}, text: "b"}
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					o(called).equals(0)
+
+					render(root, [])
+
+					o(called).equals(1)
+					o(root.childNodes.length).equals(0)
+				})
+				o("calls onbeforeremove when returning fragment", function() {
+					var called = 0
+					var component = {
+						onbeforeremove: function(vnode) {
+							called++
+
+							o(vnode.dom).notEquals(undefined)
+							o(vnode.dom).equals(root.firstChild)
+							o(root.childNodes.length).equals(1)
+						},
+						view: function() {
+							return [{tag: "div", attrs: {id: "a"}, text: "b"}]
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					o(called).equals(0)
+
+					render(root, [])
+
+					o(called).equals(1)
+					o(root.childNodes.length).equals(0)
+				})
+				o("does not recycle when there's an onupdate", function() {
+					var component = {
+						onupdate: function() {},
+						view: function() {
+							return {tag: "div"}
+						}
+					}
+					var update = o.spy()
+					var vnode = {tag: component, key: 1}
+					var updated = {tag: component, key: 1}
+
+					render(root, [vnode])
+					render(root, [])
+					render(root, [updated])
+
+					o(vnode.dom).notEquals(updated.dom)
+				})
+			})
+			o.spec("state", function() {
+				o("copies state", function() {
+					var called = 0
+					var data = {a: 1}
+					var component = {
+						data: data,
+						oninit: init,
+						view: function() {
+							return ""
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					function init(vnode) {
+						o(vnode.state.data).deepEquals(data)
+						o(vnode.state.data).equals(data)
+
+						//inherits state via prototype
+						component.x = 1
+						o(vnode.state.x).equals(1)
+					}
+				})
+				o("state copy is shallow", function() {
+					var called = 0
+					var body = {a: 1}
+					var data = [body]
+					var component = {
+						data: data,
+						oninit: init,
+						view: function() {
+							return ""
+						}
+					}
+
+					render(root, [{tag: component}])
+
+					function init(vnode) {
+						o(vnode.state.data).equals(data)
+						o(vnode.state.data[0]).equals(body)
+					}
+				})
 			})
 		})
-		o("does not calls oninit on redraw", function() {
-			var init = o.spy()
-			var component = {
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				},
-				oninit: init,
-			}
-
-			function view() {
-				return {tag: component}
-			}
-
-			render(root, view())
-			render(root, view())
-
-			o(init.callCount).equals(1)
-		})
-		o("calls oncreate", function() {
-			var called = 0
-			var component = {
-				oncreate: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				}
-			}
-			var node = {tag: component}
-
-			render(root, [node])
-
-			o(called).equals(1)
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("does not calls oncreate on redraw", function() {
-			var create = o.spy()
-			var component = {
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				},
-				oncreate: create,
-			}
-
-			function view() {
-				return {tag: component}
-			}
-
-			render(root, view())
-			render(root, view())
-
-			o(create.callCount).equals(1)
-		})
-		o("calls oncreate when returning fragment", function() {
-			var called = 0
-			var component = {
-				oncreate: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return [{tag: "div", attrs: {id: "a"}, text: "b"}]
-				}
-			}
-			var node = {tag: component}
-
-			render(root, [node])
-
-			o(called).equals(1)
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("calls onupdate", function() {
-			var called = 0
-			var component = {
-				onupdate: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			o(called).equals(0)
-
-			render(root, [{tag: component}])
-
-			o(called).equals(1)
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("calls onupdate when returning fragment", function() {
-			var called = 0
-			var component = {
-				onupdate: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return [{tag: "div", attrs: {id: "a"}, text: "b"}]
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			o(called).equals(0)
-
-			render(root, [{tag: component}])
-
-			o(called).equals(1)
-			o(root.firstChild.nodeName).equals("DIV")
-			o(root.firstChild.attributes["id"].nodeValue).equals("a")
-			o(root.firstChild.firstChild.nodeValue).equals("b")
-		})
-		o("calls onremove", function() {
-			var called = 0
-			var component = {
-				onremove: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			o(called).equals(0)
-
-			render(root, [])
-
-			o(called).equals(1)
-			o(root.childNodes.length).equals(0)
-		})
-		o("calls onremove when returning fragment", function() {
-			var called = 0
-			var component = {
-				onremove: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return [{tag: "div", attrs: {id: "a"}, text: "b"}]
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			o(called).equals(0)
-
-			render(root, [])
-
-			o(called).equals(1)
-			o(root.childNodes.length).equals(0)
-		})
-		o("calls onbeforeremove", function() {
-			var called = 0
-			var component = {
-				onbeforeremove: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return {tag: "div", attrs: {id: "a"}, text: "b"}
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			o(called).equals(0)
-
-			render(root, [])
-
-			o(called).equals(1)
-			o(root.childNodes.length).equals(0)
-		})
-		o("calls onbeforeremove when returning fragment", function() {
-			var called = 0
-			var component = {
-				onbeforeremove: function(vnode) {
-					called++
-
-					o(vnode.dom).notEquals(undefined)
-					o(vnode.dom).equals(root.firstChild)
-					o(root.childNodes.length).equals(1)
-				},
-				view: function() {
-					return [{tag: "div", attrs: {id: "a"}, text: "b"}]
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			o(called).equals(0)
-
-			render(root, [])
-
-			o(called).equals(1)
-			o(root.childNodes.length).equals(0)
-		})
-		o("does not recycle when there's an onupdate", function() {
-			var component = {
-				onupdate: function() {},
-				view: function() {
-					return {tag: "div"}
-				}
-			}
-			var update = o.spy()
-			var vnode = {tag: component, key: 1}
-			var updated = {tag: component, key: 1}
-
-			render(root, [vnode])
-			render(root, [])
-			render(root, [updated])
-
-			o(vnode.dom).notEquals(updated.dom)
-		})
 	})
-	o.spec("state", function() {
-		o("copies state", function() {
-			var called = 0
-			var data = {a: 1}
-			var component = {
-				data: data,
-				oninit: init,
-				view: function() {
-					return ""
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			function init(vnode) {
-				o(vnode.state.data).deepEquals(data)
-				o(vnode.state.data).equals(data)
-
-				//inherits state via prototype
-				component.x = 1
-				o(vnode.state.x).equals(1)
-			}
-		})
-		o("state copy is shallow", function() {
-			var called = 0
-			var body = {a: 1}
-			var data = [body]
-			var component = {
-				data: data,
-				oninit: init,
-				view: function() {
-					return ""
-				}
-			}
-
-			render(root, [{tag: component}])
-
-			function init(vnode) {
-				o(vnode.state.data).equals(data)
-				o(vnode.state.data[0]).equals(body)
-			}
-		})
-	})
-	o.spec("Alternative ways to specify componenents", function() {
+	o.spec("Alternative ways to specify components", function() {
 		o("Classes can be used as components", function() {
 			function MyComponent(vnode){
 				o(vnode.state).equals(null)

--- a/render/tests/test-onbeforeremove.js
+++ b/render/tests/test-onbeforeremove.js
@@ -2,6 +2,7 @@
 
 var o = require("../../ospec/ospec")
 var callAsync = require("../../test-utils/callAsync")
+var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 var vdom = require("../../render/render")
 var Promise = require("../../promise/promise")
@@ -169,39 +170,44 @@ o.spec("onbeforeremove", function() {
 			done()
 		})
 	})
-	o("finalizes the remove phase asynchronously when promise is returned synchronously from both attrs- and tag.onbeforeremove", function(done) {
-		var onremove = o.spy()
-		var onbeforeremove = function(){return Promise.resolve()}
-		var component = {
-			onbeforeremove: onbeforeremove,
-			onremove: onremove,
-			view: function() {},
-		}
-		render(root, [{tag: component, attrs: {onbeforeremove: onbeforeremove, onremove: onremove}}])
-		render(root, [])
-		callAsync(function() {
-			o(onremove.callCount).equals(2) // once for `tag`, once for `attrs`
-			done()
-		})
-	})
-	o("awaits promise resolution before removing the node", function(done) {
-		var view = o.spy()
-		var onremove = o.spy()
-		var onbeforeremove = function(){return new Promise(function(resolve){callAsync(resolve)})}
-		var component = {
-			onbeforeremove: onbeforeremove,
-			onremove: onremove,
-			view: view,
-		}
-		render(root, [{tag: component}])
-		render(root, [])
+	;[components[0]].forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
+			o("finalizes the remove phase asynchronously when promise is returned synchronously from both attrs- and tag.onbeforeremove", function(done) {
+				var onremove = o.spy()
+				var onbeforeremove = function(){return Promise.resolve()}
+				var component = {
+					onbeforeremove: onbeforeremove,
+					onremove: onremove,
+					view: function() {},
+				}
+				render(root, [{tag: component, attrs: {onbeforeremove: onbeforeremove, onremove: onremove}}])
+				render(root, [])
+				callAsync(function() {
+					o(onremove.callCount).equals(2) // once for `tag`, once for `attrs`
+					done()
+				})
+			})
+			o("awaits promise resolution before removing the node", function(done) {
+				var view = o.spy()
+				var onremove = o.spy()
+				var onbeforeremove = function(){return new Promise(function(resolve){callAsync(resolve)})}
+				var component = {
+					onbeforeremove: onbeforeremove,
+					onremove: onremove,
+					view: view,
+				}
+				render(root, [{tag: component}])
+				render(root, [])
 
-		callAsync(function(){
-			o(onremove.callCount).equals(0)
+				callAsync(function(){
+					o(onremove.callCount).equals(0)
 
-			callAsync(function() {
-				o(onremove.callCount).equals(1)
-				done()
+					callAsync(function() {
+						o(onremove.callCount).equals(1)
+						done()
+					})
+				})
 			})
 		})
 	})

--- a/render/tests/test-onbeforeremove.js
+++ b/render/tests/test-onbeforeremove.js
@@ -176,11 +176,11 @@ o.spec("onbeforeremove", function() {
 			o("finalizes the remove phase asynchronously when promise is returned synchronously from both attrs- and tag.onbeforeremove", function(done) {
 				var onremove = o.spy()
 				var onbeforeremove = function(){return Promise.resolve()}
-				var component = {
+				var component = createComponent({
 					onbeforeremove: onbeforeremove,
 					onremove: onremove,
 					view: function() {},
-				}
+				})
 				render(root, [{tag: component, attrs: {onbeforeremove: onbeforeremove, onremove: onremove}}])
 				render(root, [])
 				callAsync(function() {
@@ -192,11 +192,11 @@ o.spec("onbeforeremove", function() {
 				var view = o.spy()
 				var onremove = o.spy()
 				var onbeforeremove = function(){return new Promise(function(resolve){callAsync(resolve)})}
-				var component = {
+				var component = createComponent({
 					onbeforeremove: onbeforeremove,
 					onremove: onremove,
 					view: view,
-				}
+				})
 				render(root, [{tag: component}])
 				render(root, [])
 

--- a/render/tests/test-onbeforeremove.js
+++ b/render/tests/test-onbeforeremove.js
@@ -170,7 +170,7 @@ o.spec("onbeforeremove", function() {
 			done()
 		})
 	})
-	;[components[0]].forEach(function(cmp){
+	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create
 			o("finalizes the remove phase asynchronously when promise is returned synchronously from both attrs- and tag.onbeforeremove", function(done) {

--- a/render/tests/test-onbeforeupdate.js
+++ b/render/tests/test-onbeforeupdate.js
@@ -125,12 +125,12 @@ o.spec("onbeforeupdate", function() {
 			var createComponent = cmp.create
 
 			o("prevents update in component", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: function() {return false},
 					view: function(vnode) {
 						return {tag: "div", children: vnode.children}
 					},
-				}
+				})
 				var vnode = {tag: component, children: [{tag: "#", children: "a"}]}
 				var updated = {tag: component, children: [{tag: "#", children: "b"}]}
 
@@ -141,12 +141,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("prevents update if returning false in component and false in vnode", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: function() {return false},
 					view: function(vnode) {
 						return {tag: "div", attrs: {id: vnode.attrs.id}}
 					},
-				}
+				})
 				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return false}}}
 				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return false}}}
 
@@ -157,12 +157,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("does not prevent update if returning true in component and true in vnode", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: function() {return true},
 					view: function(vnode) {
 						return {tag: "div", attrs: {id: vnode.attrs.id}}
 					},
-				}
+				})
 				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return true}}}
 				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return true}}}
 
@@ -173,12 +173,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("does not prevent update if returning false in component but true in vnode", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: function() {return false},
 					view: function(vnode) {
 						return {tag: "div", attrs: {id: vnode.attrs.id}}
 					},
-				}
+				})
 				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return true}}}
 				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return true}}}
 
@@ -189,12 +189,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("does not prevent update if returning true in component but false in vnode", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: function() {return true},
 					view: function(vnode) {
 						return {tag: "div", attrs: {id: vnode.attrs.id}}
 					},
-				}
+				})
 				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return false}}}
 				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return false}}}
 
@@ -205,12 +205,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("does not prevent update if returning true from component", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: function() {return true},
 					view: function(vnode) {
 						return {tag: "div", attrs: vnode.attrs}
 					},
-				}
+				})
 				var vnode = {tag: component, attrs: {id: "a"}}
 				var updated = {tag: component, attrs: {id: "b"}}
 
@@ -221,12 +221,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("accepts arguments for comparison in component", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: onbeforeupdate,
 					view: function(vnode) {
 						return {tag: "div", attrs: vnode.attrs}
 					},
-				}
+				})
 				var count = 0
 				var vnode = {tag: component, attrs: {id: "a"}}
 				var updated = {tag: component, attrs: {id: "b"}}
@@ -248,12 +248,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("is not called on component creation", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: onbeforeupdate,
 					view: function(vnode) {
 						return {tag: "div", attrs: vnode.attrs}
 					},
-				}
+				})
 
 				var count = 0
 				var vnode = {tag: "div", attrs: {id: "a"}}
@@ -270,12 +270,12 @@ o.spec("onbeforeupdate", function() {
 			})
 
 			o("is called only once on component update", function() {
-				var component = {
+				var component = createComponent({
 					onbeforeupdate: onbeforeupdate,
 					view: function(vnode) {
 						return {tag: "div", attrs: vnode.attrs}
 					},
-				}
+				})
 
 				var count = 0
 				var vnode = {tag: component, attrs: {id: "a"}}

--- a/render/tests/test-onbeforeupdate.js
+++ b/render/tests/test-onbeforeupdate.js
@@ -120,7 +120,7 @@ o.spec("onbeforeupdate", function() {
 		o(count).equals(1)
 	})
 
-	;[components[0]].forEach(function(cmp){
+	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create
 

--- a/render/tests/test-onbeforeupdate.js
+++ b/render/tests/test-onbeforeupdate.js
@@ -120,171 +120,177 @@ o.spec("onbeforeupdate", function() {
 		o(count).equals(1)
 	})
 
-	o("prevents update in component", function() {
-		var component = {
-			onbeforeupdate: function() {return false},
-			view: function(vnode) {
-				return {tag: "div", children: vnode.children}
-			},
-		}
-		var vnode = {tag: component, children: [{tag: "#", children: "a"}]}
-		var updated = {tag: component, children: [{tag: "#", children: "b"}]}
+	;[components[0]].forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
 
-		render(root, [vnode])
-		render(root, [updated])
+			o("prevents update in component", function() {
+				var component = {
+					onbeforeupdate: function() {return false},
+					view: function(vnode) {
+						return {tag: "div", children: vnode.children}
+					},
+				}
+				var vnode = {tag: component, children: [{tag: "#", children: "a"}]}
+				var updated = {tag: component, children: [{tag: "#", children: "b"}]}
 
-		o(root.firstChild.firstChild.nodeValue).equals("a")
-	})
+				render(root, [vnode])
+				render(root, [updated])
 
-	o("prevents update if returning false in component and false in vnode", function() {
-		var component = {
-			onbeforeupdate: function() {return false},
-			view: function(vnode) {
-				return {tag: "div", attrs: {id: vnode.attrs.id}}
-			},
-		}
-		var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return false}}}
-		var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return false}}}
+				o(root.firstChild.firstChild.nodeValue).equals("a")
+			})
 
-		render(root, [vnode])
-		render(root, [updated])
+			o("prevents update if returning false in component and false in vnode", function() {
+				var component = {
+					onbeforeupdate: function() {return false},
+					view: function(vnode) {
+						return {tag: "div", attrs: {id: vnode.attrs.id}}
+					},
+				}
+				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return false}}}
+				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return false}}}
 
-		o(root.firstChild.attributes["id"].nodeValue).equals("a")
-	})
+				render(root, [vnode])
+				render(root, [updated])
 
-	o("does not prevent update if returning true in component and true in vnode", function() {
-		var component = {
-			onbeforeupdate: function() {return true},
-			view: function(vnode) {
-				return {tag: "div", attrs: {id: vnode.attrs.id}}
-			},
-		}
-		var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return true}}}
-		var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return true}}}
+				o(root.firstChild.attributes["id"].nodeValue).equals("a")
+			})
 
-		render(root, [vnode])
-		render(root, [updated])
+			o("does not prevent update if returning true in component and true in vnode", function() {
+				var component = {
+					onbeforeupdate: function() {return true},
+					view: function(vnode) {
+						return {tag: "div", attrs: {id: vnode.attrs.id}}
+					},
+				}
+				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return true}}}
+				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return true}}}
 
-		o(root.firstChild.attributes["id"].nodeValue).equals("b")
-	})
+				render(root, [vnode])
+				render(root, [updated])
 
-	o("does not prevent update if returning false in component but true in vnode", function() {
-		var component = {
-			onbeforeupdate: function() {return false},
-			view: function(vnode) {
-				return {tag: "div", attrs: {id: vnode.attrs.id}}
-			},
-		}
-		var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return true}}}
-		var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return true}}}
+				o(root.firstChild.attributes["id"].nodeValue).equals("b")
+			})
 
-		render(root, [vnode])
-		render(root, [updated])
+			o("does not prevent update if returning false in component but true in vnode", function() {
+				var component = {
+					onbeforeupdate: function() {return false},
+					view: function(vnode) {
+						return {tag: "div", attrs: {id: vnode.attrs.id}}
+					},
+				}
+				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return true}}}
+				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return true}}}
 
-		o(root.firstChild.attributes["id"].nodeValue).equals("b")
-	})
+				render(root, [vnode])
+				render(root, [updated])
 
-	o("does not prevent update if returning true in component but false in vnode", function() {
-		var component = {
-			onbeforeupdate: function() {return true},
-			view: function(vnode) {
-				return {tag: "div", attrs: {id: vnode.attrs.id}}
-			},
-		}
-		var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return false}}}
-		var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return false}}}
+				o(root.firstChild.attributes["id"].nodeValue).equals("b")
+			})
 
-		render(root, [vnode])
-		render(root, [updated])
+			o("does not prevent update if returning true in component but false in vnode", function() {
+				var component = {
+					onbeforeupdate: function() {return true},
+					view: function(vnode) {
+						return {tag: "div", attrs: {id: vnode.attrs.id}}
+					},
+				}
+				var vnode = {tag: component, attrs: {id: "a", onbeforeupdate: function() {return false}}}
+				var updated = {tag: component, attrs: {id: "b", onbeforeupdate: function() {return false}}}
 
-		o(root.firstChild.attributes["id"].nodeValue).equals("b")
-	})
+				render(root, [vnode])
+				render(root, [updated])
 
-	o("does not prevent update if returning true from component", function() {
-		var component = {
-			onbeforeupdate: function() {return true},
-			view: function(vnode) {
-				return {tag: "div", attrs: vnode.attrs}
-			},
-		}
-		var vnode = {tag: component, attrs: {id: "a"}}
-		var updated = {tag: component, attrs: {id: "b"}}
+				o(root.firstChild.attributes["id"].nodeValue).equals("b")
+			})
 
-		render(root, [vnode])
-		render(root, [updated])
+			o("does not prevent update if returning true from component", function() {
+				var component = {
+					onbeforeupdate: function() {return true},
+					view: function(vnode) {
+						return {tag: "div", attrs: vnode.attrs}
+					},
+				}
+				var vnode = {tag: component, attrs: {id: "a"}}
+				var updated = {tag: component, attrs: {id: "b"}}
 
-		o(root.firstChild.attributes["id"].nodeValue).equals("b")
-	})
+				render(root, [vnode])
+				render(root, [updated])
 
-	o("accepts arguments for comparison in component", function() {
-		var component = {
-			onbeforeupdate: onbeforeupdate,
-			view: function(vnode) {
-				return {tag: "div", attrs: vnode.attrs}
-			},
-		}
-		var count = 0
-		var vnode = {tag: component, attrs: {id: "a"}}
-		var updated = {tag: component, attrs: {id: "b"}}
+				o(root.firstChild.attributes["id"].nodeValue).equals("b")
+			})
 
-		render(root, [vnode])
-		render(root, [updated])
+			o("accepts arguments for comparison in component", function() {
+				var component = {
+					onbeforeupdate: onbeforeupdate,
+					view: function(vnode) {
+						return {tag: "div", attrs: vnode.attrs}
+					},
+				}
+				var count = 0
+				var vnode = {tag: component, attrs: {id: "a"}}
+				var updated = {tag: component, attrs: {id: "b"}}
 
-		function onbeforeupdate(vnode, old) {
-			count++
+				render(root, [vnode])
+				render(root, [updated])
 
-			o(old.attrs.id).equals("a")
-			o(vnode.attrs.id).equals("b")
+				function onbeforeupdate(vnode, old) {
+					count++
 
-			return old.attrs.id !== vnode.attrs.id
-		}
+					o(old.attrs.id).equals("a")
+					o(vnode.attrs.id).equals("b")
 
-		o(count).equals(1)
-		o(root.firstChild.attributes["id"].nodeValue).equals("b")
-	})
+					return old.attrs.id !== vnode.attrs.id
+				}
 
-	o("is not called on component creation", function() {
-		var component = {
-			onbeforeupdate: onbeforeupdate,
-			view: function(vnode) {
-				return {tag: "div", attrs: vnode.attrs}
-			},
-		}
+				o(count).equals(1)
+				o(root.firstChild.attributes["id"].nodeValue).equals("b")
+			})
 
-		var count = 0
-		var vnode = {tag: "div", attrs: {id: "a"}}
-		var updated = {tag: "div", attrs: {id: "b"}}
+			o("is not called on component creation", function() {
+				var component = {
+					onbeforeupdate: onbeforeupdate,
+					view: function(vnode) {
+						return {tag: "div", attrs: vnode.attrs}
+					},
+				}
 
-		render(root, [vnode])
+				var count = 0
+				var vnode = {tag: "div", attrs: {id: "a"}}
+				var updated = {tag: "div", attrs: {id: "b"}}
 
-		function onbeforeupdate(vnode, old) {
-			count++
-			return true
-		}
+				render(root, [vnode])
 
-		o(count).equals(0)
-	})
+				function onbeforeupdate(vnode, old) {
+					count++
+					return true
+				}
 
-	o("is called only once on component update", function() {
-		var component = {
-			onbeforeupdate: onbeforeupdate,
-			view: function(vnode) {
-				return {tag: "div", attrs: vnode.attrs}
-			},
-		}
+				o(count).equals(0)
+			})
 
-		var count = 0
-		var vnode = {tag: component, attrs: {id: "a"}}
-		var updated = {tag: component, attrs: {id: "b"}}
+			o("is called only once on component update", function() {
+				var component = {
+					onbeforeupdate: onbeforeupdate,
+					view: function(vnode) {
+						return {tag: "div", attrs: vnode.attrs}
+					},
+				}
 
-		render(root, [vnode])
-		render(root, [updated])
+				var count = 0
+				var vnode = {tag: component, attrs: {id: "a"}}
+				var updated = {tag: component, attrs: {id: "b"}}
 
-		function onbeforeupdate(vnode, old) {
-			count++
-			return true
-		}
+				render(root, [vnode])
+				render(root, [updated])
 
-		o(count).equals(1)
+				function onbeforeupdate(vnode, old) {
+					count++
+					return true
+				}
+
+				o(count).equals(1)
+			})
+		})
 	})
 })

--- a/render/tests/test-onbeforeupdate.js
+++ b/render/tests/test-onbeforeupdate.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var o = require("../../ospec/ospec")
+var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 var vdom = require("../../render/render")
 
@@ -54,6 +55,69 @@ o.spec("onbeforeupdate", function() {
 		render(root, [updated])
 
 		o(root.firstChild.nodeValue).equals("a")
+	})
+
+	o("does not prevent update if returning true", function() {
+		var onbeforeupdate = function() {return true}
+		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
+		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		o(root.firstChild.attributes["id"].nodeValue).equals("b")
+	})
+
+	o("accepts arguments for comparison", function() {
+		var count = 0
+		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
+		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		function onbeforeupdate(vnode, old) {
+			count++
+
+			o(old.attrs.id).equals("a")
+			o(vnode.attrs.id).equals("b")
+
+			return old.attrs.id !== vnode.attrs.id
+		}
+
+		o(count).equals(1)
+		o(root.firstChild.attributes["id"].nodeValue).equals("b")
+	})
+
+	o("is not called on creation", function() {
+		var count = 0
+		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
+		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
+
+		render(root, [vnode])
+
+		function onbeforeupdate(vnode, old) {
+			count++
+			return true
+		}
+
+		o(count).equals(0)
+	})
+
+	o("is called only once on update", function() {
+		var count = 0
+		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
+		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		function onbeforeupdate(vnode, old) {
+			count++
+			return true
+		}
+
+		o(count).equals(1)
 	})
 
 	o("prevents update in component", function() {
@@ -136,17 +200,6 @@ o.spec("onbeforeupdate", function() {
 		o(root.firstChild.attributes["id"].nodeValue).equals("b")
 	})
 
-	o("does not prevent update if returning true", function() {
-		var onbeforeupdate = function() {return true}
-		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
-		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
-
-		render(root, [vnode])
-		render(root, [updated])
-
-		o(root.firstChild.attributes["id"].nodeValue).equals("b")
-	})
-
 	o("does not prevent update if returning true from component", function() {
 		var component = {
 			onbeforeupdate: function() {return true},
@@ -160,27 +213,6 @@ o.spec("onbeforeupdate", function() {
 		render(root, [vnode])
 		render(root, [updated])
 
-		o(root.firstChild.attributes["id"].nodeValue).equals("b")
-	})
-
-	o("accepts arguments for comparison", function() {
-		var count = 0
-		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
-		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
-
-		render(root, [vnode])
-		render(root, [updated])
-
-		function onbeforeupdate(vnode, old) {
-			count++
-
-			o(old.attrs.id).equals("a")
-			o(vnode.attrs.id).equals("b")
-
-			return old.attrs.id !== vnode.attrs.id
-		}
-
-		o(count).equals(1)
 		o(root.firstChild.attributes["id"].nodeValue).equals("b")
 	})
 
@@ -211,21 +243,6 @@ o.spec("onbeforeupdate", function() {
 		o(root.firstChild.attributes["id"].nodeValue).equals("b")
 	})
 
-	o("is not called on creation", function() {
-		var count = 0
-		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
-		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
-
-		render(root, [vnode])
-
-		function onbeforeupdate(vnode, old) {
-			count++
-			return true
-		}
-
-		o(count).equals(0)
-	})
-
 	o("is not called on component creation", function() {
 		var component = {
 			onbeforeupdate: onbeforeupdate,
@@ -246,22 +263,6 @@ o.spec("onbeforeupdate", function() {
 		}
 
 		o(count).equals(0)
-	})
-
-	o("is called only once on update", function() {
-		var count = 0
-		var vnode = {tag: "div", attrs: {id: "a", onbeforeupdate: onbeforeupdate}}
-		var updated = {tag: "div", attrs: {id: "b", onbeforeupdate: onbeforeupdate}}
-
-		render(root, [vnode])
-		render(root, [updated])
-
-		function onbeforeupdate(vnode, old) {
-			count++
-			return true
-		}
-
-		o(count).equals(1)
 	})
 
 	o("is called only once on component update", function() {

--- a/render/tests/test-onremove.js
+++ b/render/tests/test-onremove.js
@@ -113,37 +113,43 @@ o.spec("onremove", function() {
 
 		o(vnode.dom).notEquals(updated.dom)
 	})
-	o("calls onremove on nested component", function() {
-		var spy = o.spy()
-		var comp = {
-			view: function() {return m(outer)}
-		}
-		var outer = {
-			view: function() {return m(inner)}
-		}
-		var inner = {
-			onremove: spy,
-			view: function() {return m("div")}
-		}
-		render(root, {tag: comp})
-		render(root, null)
-		
-		o(spy.callCount).equals(1)
-	})
-	o("calls onremove on nested component child", function() {
-		var spy = o.spy()
-		var comp = {
-			view: function() {return m(outer)}
-		}
-		var outer = {
-			view: function() {return m(inner, m("a", {onremove: spy}))}
-		}
-		var inner = {
-			view: function(vnode) {return m("div", vnode.children)}
-		}
-		render(root, {tag: comp})
-		render(root, null)
-		
-		o(spy.callCount).equals(1)
+	;[components[0]].forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
+
+			o("calls onremove on nested component", function() {
+				var spy = o.spy()
+				var comp = {
+					view: function() {return m(outer)}
+				}
+				var outer = {
+					view: function() {return m(inner)}
+				}
+				var inner = {
+					onremove: spy,
+					view: function() {return m("div")}
+				}
+				render(root, {tag: comp})
+				render(root, null)
+				
+				o(spy.callCount).equals(1)
+			})
+			o("calls onremove on nested component child", function() {
+				var spy = o.spy()
+				var comp = {
+					view: function() {return m(outer)}
+				}
+				var outer = {
+					view: function() {return m(inner, m("a", {onremove: spy}))}
+				}
+				var inner = {
+					view: function(vnode) {return m("div", vnode.children)}
+				}
+				render(root, {tag: comp})
+				render(root, null)
+				
+				o(spy.callCount).equals(1)
+			})
+		})
 	})
 })

--- a/render/tests/test-onremove.js
+++ b/render/tests/test-onremove.js
@@ -113,7 +113,7 @@ o.spec("onremove", function() {
 
 		o(vnode.dom).notEquals(updated.dom)
 	})
-	;[components[0]].forEach(function(cmp){
+	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create
 

--- a/render/tests/test-onremove.js
+++ b/render/tests/test-onremove.js
@@ -119,16 +119,16 @@ o.spec("onremove", function() {
 
 			o("calls onremove on nested component", function() {
 				var spy = o.spy()
-				var comp = {
+				var comp = createComponent({
 					view: function() {return m(outer)}
-				}
-				var outer = {
+				})
+				var outer = createComponent({
 					view: function() {return m(inner)}
-				}
-				var inner = {
+				})
+				var inner = createComponent({
 					onremove: spy,
 					view: function() {return m("div")}
-				}
+				})
 				render(root, {tag: comp})
 				render(root, null)
 				
@@ -136,15 +136,15 @@ o.spec("onremove", function() {
 			})
 			o("calls onremove on nested component child", function() {
 				var spy = o.spy()
-				var comp = {
+				var comp = createComponent({
 					view: function() {return m(outer)}
-				}
-				var outer = {
+				})
+				var outer = createComponent({
 					view: function() {return m(inner, m("a", {onremove: spy}))}
-				}
-				var inner = {
+				})
+				var inner = createComponent({
 					view: function(vnode) {return m("div", vnode.children)}
-				}
+				})
 				render(root, {tag: comp})
 				render(root, null)
 				

--- a/render/tests/test-onremove.js
+++ b/render/tests/test-onremove.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var o = require("../../ospec/ospec")
+var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 var vdom = require("../../render/render")
 var m = require("../../render/hyperscript")
@@ -80,6 +81,38 @@ o.spec("onremove", function() {
 		o(remove.this).equals(vnode.state)
 		o(remove.args[0]).equals(vnode)
 	})
+	o("does not set onremove as an event handler", function() {
+		var remove = o.spy()
+		var vnode = {tag: "div", attrs: {onremove: remove}, children: []}
+
+		render(root, [vnode])
+
+		o(vnode.dom.onremove).equals(undefined)
+		o(vnode.dom.attributes["onremove"]).equals(undefined)
+	})
+	o("calls onremove on recycle", function() {
+		var remove = o.spy()
+		var vnodes = [{tag: "div", key: 1}]
+		var temp = [{tag: "div", key: 2, attrs: {onremove: remove}}]
+		var updated = [{tag: "div", key: 1}]
+
+		render(root, vnodes)
+		render(root, temp)
+		render(root, updated)
+
+		o(remove.callCount).equals(1)
+	})
+	o("does not recycle when there's an onremove", function() {
+		var remove = o.spy()
+		var vnode = {tag: "div", key: 1, attrs: {onremove: remove}}
+		var updated = {tag: "div", key: 1, attrs: {onremove: remove}}
+
+		render(root, [vnode])
+		render(root, [])
+		render(root, [updated])
+
+		o(vnode.dom).notEquals(updated.dom)
+	})
 	o("calls onremove on nested component", function() {
 		var spy = o.spy()
 		var comp = {
@@ -112,37 +145,5 @@ o.spec("onremove", function() {
 		render(root, null)
 		
 		o(spy.callCount).equals(1)
-	})
-	o("does not set onremove as an event handler", function() {
-		var remove = o.spy()
-		var vnode = {tag: "div", attrs: {onremove: remove}, children: []}
-
-		render(root, [vnode])
-
-		o(vnode.dom.onremove).equals(undefined)
-		o(vnode.dom.attributes["onremove"]).equals(undefined)
-	})
-	o("calls onremove on recycle", function() {
-		var remove = o.spy()
-		var vnodes = [{tag: "div", key: 1}]
-		var temp = [{tag: "div", key: 2, attrs: {onremove: remove}}]
-		var updated = [{tag: "div", key: 1}]
-
-		render(root, vnodes)
-		render(root, temp)
-		render(root, updated)
-
-		o(remove.callCount).equals(1)
-	})
-	o("does not recycle when there's an onremove", function() {
-		var remove = o.spy()
-		var vnode = {tag: "div", key: 1, attrs: {onremove: remove}}
-		var updated = {tag: "div", key: 1, attrs: {onremove: remove}}
-
-		render(root, [vnode])
-		render(root, [])
-		render(root, [updated])
-
-		o(vnode.dom).notEquals(updated.dom)
 	})
 })

--- a/render/tests/test-render.js
+++ b/render/tests/test-render.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var o = require("../../ospec/ospec")
+var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 var vdom = require("../../render/render")
 
@@ -118,7 +119,7 @@ o.spec("render", function() {
 		o(oninit.callCount).equals(0)
 		o(onbeforeupdate.callCount).equals(0)
 	})
-	o("does not try to re-initialize a factory component whose view has thrown", function() {
+	o("does not try to re-initialize a closure component whose view has thrown", function() {
 		var oninit = o.spy()
 		var onbeforeupdate = o.spy()
 		function A() {
@@ -141,7 +142,7 @@ o.spec("render", function() {
 		o(oninit.callCount).equals(1)
 		o(onbeforeupdate.callCount).equals(0)
 	})
-	o("does not try to re-initialize a factory component whose oninit has thrown", function() {
+	o("does not try to re-initialize a closure component whose oninit has thrown", function() {
 		var oninit = o.spy(function(vnode) {throw new Error("error")})
 		var onbeforeupdate = o.spy()
 		function A() {
@@ -164,7 +165,7 @@ o.spec("render", function() {
 		o(oninit.callCount).equals(1)
 		o(onbeforeupdate.callCount).equals(0)
 	})
-	o("does not try to re-initialize a factory component whose factory has thrown", function() {
+	o("does not try to re-initialize a closure component whose closure has thrown", function() {
 		function A() {
 			throw new Error("error")
 		}

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -905,7 +905,7 @@ o.spec("updateNodes", function() {
 		
 		o(vnode.dom).notEquals(updated.dom)
 	})
-	;[components[0]].forEach(function(cmp){
+	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create
 

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -910,7 +910,7 @@ o.spec("updateNodes", function() {
 			var createComponent = cmp.create
 
 			o("fragment child toggles from null when followed by null component then tag", function() {
-				var component = {view: function() {return null}}
+				var component = createComponent({view: function() {return null}})
 				var vnodes = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
 				var temp = [{tag: "[", children: [null, {tag: component}, {tag: "b"}]}]
 				var updated = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
@@ -925,8 +925,8 @@ o.spec("updateNodes", function() {
 			})
 			o("fragment child toggles from null in component when followed by null component then tag", function() {
 				var flag = true
-				var a = {view: function() {return flag ? {tag: "a"} : null}}
-				var b = {view: function() {return null}}
+				var a = createComponent({view: function() {return flag ? {tag: "a"} : null}})
+				var b = createComponent({view: function() {return null}})
 				var vnodes = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
 				var temp = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
 				var updated = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -905,36 +905,42 @@ o.spec("updateNodes", function() {
 		
 		o(vnode.dom).notEquals(updated.dom)
 	})
-	o("fragment child toggles from null when followed by null component then tag", function() {
-		var component = {view: function() {return null}}
-		var vnodes = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
-		var temp = [{tag: "[", children: [null, {tag: component}, {tag: "b"}]}]
-		var updated = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
+	;[components[0]].forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
 
-		render(root, vnodes)
-		render(root, temp)
-		render(root, updated)
+			o("fragment child toggles from null when followed by null component then tag", function() {
+				var component = {view: function() {return null}}
+				var vnodes = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
+				var temp = [{tag: "[", children: [null, {tag: component}, {tag: "b"}]}]
+				var updated = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
 
-		o(root.childNodes.length).equals(2)
-		o(root.childNodes[0].nodeName).equals("A")
-		o(root.childNodes[1].nodeName).equals("B")
-	})
-	o("fragment child toggles from null in component when followed by null component then tag", function() {
-		var flag = true
-		var a = {view: function() {return flag ? {tag: "a"} : null}}
-		var b = {view: function() {return null}}
-		var vnodes = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
-		var temp = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
-		var updated = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
+				render(root, vnodes)
+				render(root, temp)
+				render(root, updated)
 
-		render(root, vnodes)
-		flag = false
-		render(root, temp)
-		flag = true
-		render(root, updated)
+				o(root.childNodes.length).equals(2)
+				o(root.childNodes[0].nodeName).equals("A")
+				o(root.childNodes[1].nodeName).equals("B")
+			})
+			o("fragment child toggles from null in component when followed by null component then tag", function() {
+				var flag = true
+				var a = {view: function() {return flag ? {tag: "a"} : null}}
+				var b = {view: function() {return null}}
+				var vnodes = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
+				var temp = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
+				var updated = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
 
-		o(root.childNodes.length).equals(2)
-		o(root.childNodes[0].nodeName).equals("A")
-		o(root.childNodes[1].nodeName).equals("S")
+				render(root, vnodes)
+				flag = false
+				render(root, temp)
+				flag = true
+				render(root, updated)
+
+				o(root.childNodes.length).equals(2)
+				o(root.childNodes[0].nodeName).equals("A")
+				o(root.childNodes[1].nodeName).equals("S")
+			})
+		})
 	})
 })

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var o = require("../../ospec/ospec")
+var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 var vdom = require("../../render/render")
 
@@ -838,38 +839,6 @@ o.spec("updateNodes", function() {
 		o(root.childNodes[0].nodeName).equals("A")
 		o(root.childNodes[1].nodeName).equals("B")
 	})
-	o("fragment child toggles from null when followed by null component then tag", function() {
-		var component = {view: function() {return null}}
-		var vnodes = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
-		var temp = [{tag: "[", children: [null, {tag: component}, {tag: "b"}]}]
-		var updated = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
-
-		render(root, vnodes)
-		render(root, temp)
-		render(root, updated)
-
-		o(root.childNodes.length).equals(2)
-		o(root.childNodes[0].nodeName).equals("A")
-		o(root.childNodes[1].nodeName).equals("B")
-	})
-	o("fragment child toggles from null in component when followed by null component then tag", function() {
-		var flag = true
-		var a = {view: function() {return flag ? {tag: "a"} : null}}
-		var b = {view: function() {return null}}
-		var vnodes = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
-		var temp = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
-		var updated = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
-
-		render(root, vnodes)
-		flag = false
-		render(root, temp)
-		flag = true
-		render(root, updated)
-
-		o(root.childNodes.length).equals(2)
-		o(root.childNodes[0].nodeName).equals("A")
-		o(root.childNodes[1].nodeName).equals("S")
-	})
 	o("cached, non-keyed nodes skip diff", function () {
 		var onupdate = o.spy();
 		var cached = {tag:"a", attrs:{onupdate: onupdate}}
@@ -926,7 +895,7 @@ o.spec("updateNodes", function() {
 		o(update.callCount).equals(2)
 		o(remove.callCount).equals(0)
 	})
-	o("component is recreated if key changes to undefined", function () {
+	o("node is recreated if key changes to undefined", function () {
 		var vnode = {tag: "b", key: 1}
 		var updated = {tag: "b"}
 		
@@ -935,5 +904,37 @@ o.spec("updateNodes", function() {
 		render(root, updated)
 		
 		o(vnode.dom).notEquals(updated.dom)
+	})
+	o("fragment child toggles from null when followed by null component then tag", function() {
+		var component = {view: function() {return null}}
+		var vnodes = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
+		var temp = [{tag: "[", children: [null, {tag: component}, {tag: "b"}]}]
+		var updated = [{tag: "[", children: [{tag: "a"}, {tag: component}, {tag: "b"}]}]
+
+		render(root, vnodes)
+		render(root, temp)
+		render(root, updated)
+
+		o(root.childNodes.length).equals(2)
+		o(root.childNodes[0].nodeName).equals("A")
+		o(root.childNodes[1].nodeName).equals("B")
+	})
+	o("fragment child toggles from null in component when followed by null component then tag", function() {
+		var flag = true
+		var a = {view: function() {return flag ? {tag: "a"} : null}}
+		var b = {view: function() {return null}}
+		var vnodes = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
+		var temp = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
+		var updated = [{tag: "[", children: [{tag: a}, {tag: b}, {tag: "s"}]}]
+
+		render(root, vnodes)
+		flag = false
+		render(root, temp)
+		flag = true
+		render(root, updated)
+
+		o(root.childNodes.length).equals(2)
+		o(root.childNodes[0].nodeName).equals("A")
+		o(root.childNodes[1].nodeName).equals("S")
 	})
 })

--- a/test-utils/components.js
+++ b/test-utils/components.js
@@ -1,0 +1,27 @@
+module.exports = [
+  {
+    kind: 'POJO',
+    create: function(methods) {
+      var res = {view: function() {return {tag:'div'}}}
+      Object.keys(methods || {}).forEach(function(m){res[m] = methods[m]})
+      return res
+    }
+  }, {
+    kind: 'constructible',
+    create: function(methods) {
+      function res(){}
+      res.prototype.view = function() {return {tag:'div'}}
+      Object.keys(methods || {}).forEach(function(m){res.prototype[m] = methods[m]})
+      return res
+    }
+  }, {
+    kind: 'closure',
+    create: function(methods) {
+      return function() {
+        var res = {view: function() {return {tag:'div'}}}
+        Object.keys(methods || {}).forEach(function(m){res[m] = methods[m]})
+        return res
+      }
+    }
+  }
+]

--- a/test-utils/tests/index.html
+++ b/test-utils/tests/index.html
@@ -14,12 +14,14 @@
 		<script src="../../test-utils/xhrMock.js"></script>
 		<script src="../../test-utils/domMock.js"></script>
 		<script src="../../test-utils/browserMock.js"></script>
+		<script src="../../test-utils/component.js"></script>
 		<script src="test-callAsync.js"></script>
 		<script src="test-parseURL.js"></script>
 		<script src="test-pushStateMock.js"></script>
 		<script src="test-xhrMock.js"></script>
 		<script src="test-domMock.js"></script>
 		<script src="test-browserMock.js"></script>
+		<script src="test-component.js"></script>
 
 		<script>require("../../ospec/ospec").run()</script>
 	</body>

--- a/test-utils/tests/test-components.js
+++ b/test-utils/tests/test-components.js
@@ -1,0 +1,54 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var components = require("../../test-utils/components")
+
+o.spec("test-utils/components", function() {
+  var test = o.spy(function(component) {
+    return function() {
+      o('works', function() {
+        o(typeof component.kind).equals('string')
+
+        var methods = {oninit: function(){}, view: function(){}}
+
+        var cmp1, cmp2
+
+        if (component.kind === "POJO") {
+          cmp1 = component.create()
+          cmp2 = component.create(methods)
+        } else if (component.kind === "constructible") {
+          cmp1 = new (component.create())
+          cmp2 = new (component.create(methods))
+        } else if (component.kind === "closure") {
+          cmp1 = component.create()()
+          cmp2 = component.create(methods)()          
+        } else {
+          throw new Error("unexpected component kind")
+        }
+
+        o(cmp1 != null).equals(true)
+        o(typeof cmp1.view).equals("function")
+
+        var vnode = cmp1.view()
+
+        o(vnode != null).equals(true)
+        o(vnode).deepEquals({tag: "div"})
+
+        if (component.kind !== 'constructible') {
+          o(cmp2).deepEquals(methods)
+        } else {
+          // deepEquals doesn't search the prototype, do it manually
+          o(cmp2 != null).equals(true)
+          o(cmp2.view).equals(methods.view)
+          o(cmp2.oninit).equals(methods.oninit)
+        }
+      })
+    }
+  })
+  o.after(function(){
+    o(test.callCount).equals(3)
+  })
+  components.forEach(function(component) {
+    o.spec(component.kind, test(component))
+  })
+})

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -88,7 +88,7 @@ o.spec("api", function() {
 			o(root.firstChild.nodeName).equals("DIV")
 		})
 	})
-	;[components[0]].forEach(function(cmp){
+	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create
 

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -68,6 +68,16 @@ o.spec("api", function() {
 			o(query).equals("a=1&b=2")
 		})
 	})
+	o.spec("m.request", function() {
+		o("works", function() {
+			o(typeof m.request).equals("function") // TODO improve
+		})
+	})
+	o.spec("m.jsonp", function() {
+		o("works", function() {
+			o(typeof m.jsonp).equals("function") // TODO improve
+		})
+	})
 	o.spec("m.render", function() {
 		o("works", function() {
 			var root = window.document.createElement("div")
@@ -155,16 +165,6 @@ o.spec("api", function() {
 
 				done()
 			}, FRAME_BUDGET)
-		})
-	})
-	o.spec("m.request", function() {
-		o("works", function() {
-			o(typeof m.request).equals("function") // TODO improve
-		})
-	})
-	o.spec("m.jsonp", function() {
-		o("works", function() {
-			o(typeof m.jsonp).equals("function") // TODO improve
 		})
 	})
 })

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -95,7 +95,7 @@ o.spec("api", function() {
 			o.spec("m.mount", function() {
 				o("works", function() {
 					var root = window.document.createElement("div")
-					m.mount(root, {view: function() {return m("div")}})
+					m.mount(root, createComponent({view: function() {return m("div")}}))
 
 					o(root.childNodes.length).equals(1)
 					o(root.firstChild.nodeName).equals("DIV")
@@ -105,7 +105,7 @@ o.spec("api", function() {
 				o("works", function(done) {
 					var root = window.document.createElement("div")
 					m.route(root, "/a", {
-						"/a": {view: function() {return m("div")}}
+						"/a": createComponent({view: function() {return m("div")}})
 					})
 
 					setTimeout(function() {
@@ -119,7 +119,7 @@ o.spec("api", function() {
 					var root = window.document.createElement("div")
 					m.route.prefix("#")
 					m.route(root, "/a", {
-						"/a": {view: function() {return m("div")}}
+						"/a": createComponent({view: function() {return m("div")}})
 					})
 
 					setTimeout(function() {
@@ -132,7 +132,7 @@ o.spec("api", function() {
 				o("m.route.get", function(done) {
 					var root = window.document.createElement("div")
 					m.route(root, "/a", {
-						"/a": {view: function() {return m("div")}}
+						"/a": createComponent({view: function() {return m("div")}})
 					})
 
 					setTimeout(function() {
@@ -145,7 +145,7 @@ o.spec("api", function() {
 					timeout(100)
 					var root = window.document.createElement("div")
 					m.route(root, "/a", {
-						"/:id": {view: function() {return m("div")}}
+						"/:id": createComponent({view: function() {return m("div")}})
 					})
 
 					setTimeout(function() {
@@ -162,7 +162,7 @@ o.spec("api", function() {
 				o("works", function(done) {
 					var count = 0
 					var root = window.document.createElement("div")
-					m.mount(root, {view: function() {count++}})
+					m.mount(root, createComponent({view: function() {count++}}))
 					setTimeout(function() {
 						m.redraw()
 

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -2,6 +2,7 @@
 
 var o = require("../ospec/ospec")
 var browserMock = require("../test-utils/browserMock")
+var components = require("../test-utils/components")
 
 o.spec("api", function() {
 	var m
@@ -87,84 +88,90 @@ o.spec("api", function() {
 			o(root.firstChild.nodeName).equals("DIV")
 		})
 	})
-	o.spec("m.mount", function() {
-		o("works", function() {
-			var root = window.document.createElement("div")
-			m.mount(root, {view: function() {return m("div")}})
+	;[components[0]].forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
 
-			o(root.childNodes.length).equals(1)
-			o(root.firstChild.nodeName).equals("DIV")
-		})
-	})
-	o.spec("m.route", function() {
-		o("works", function(done) {
-			var root = window.document.createElement("div")
-			m.route(root, "/a", {
-				"/a": {view: function() {return m("div")}}
+			o.spec("m.mount", function() {
+				o("works", function() {
+					var root = window.document.createElement("div")
+					m.mount(root, {view: function() {return m("div")}})
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("DIV")
+				})
 			})
+			o.spec("m.route", function() {
+				o("works", function(done) {
+					var root = window.document.createElement("div")
+					m.route(root, "/a", {
+						"/a": {view: function() {return m("div")}}
+					})
 
-			setTimeout(function() {
-				o(root.childNodes.length).equals(1)
-				o(root.firstChild.nodeName).equals("DIV")
+					setTimeout(function() {
+						o(root.childNodes.length).equals(1)
+						o(root.firstChild.nodeName).equals("DIV")
 
-				done()
-			}, FRAME_BUDGET)
-		})
-		o("m.route.prefix", function(done) {
-			var root = window.document.createElement("div")
-			m.route.prefix("#")
-			m.route(root, "/a", {
-				"/a": {view: function() {return m("div")}}
+						done()
+					}, FRAME_BUDGET)
+				})
+				o("m.route.prefix", function(done) {
+					var root = window.document.createElement("div")
+					m.route.prefix("#")
+					m.route(root, "/a", {
+						"/a": {view: function() {return m("div")}}
+					})
+
+					setTimeout(function() {
+						o(root.childNodes.length).equals(1)
+						o(root.firstChild.nodeName).equals("DIV")
+
+						done()
+					}, FRAME_BUDGET)
+				})
+				o("m.route.get", function(done) {
+					var root = window.document.createElement("div")
+					m.route(root, "/a", {
+						"/a": {view: function() {return m("div")}}
+					})
+
+					setTimeout(function() {
+						o(m.route.get()).equals("/a")
+
+						done()
+					}, FRAME_BUDGET)
+				})
+				o("m.route.set", function(done, timeout) {
+					timeout(100)
+					var root = window.document.createElement("div")
+					m.route(root, "/a", {
+						"/:id": {view: function() {return m("div")}}
+					})
+
+					setTimeout(function() {
+						m.route.set("/b")
+						setTimeout(function() {
+							o(m.route.get()).equals("/b")
+
+							done()
+						}, FRAME_BUDGET)
+					}, FRAME_BUDGET)
+				})
 			})
+			o.spec("m.redraw", function() {
+				o("works", function(done) {
+					var count = 0
+					var root = window.document.createElement("div")
+					m.mount(root, {view: function() {count++}})
+					setTimeout(function() {
+						m.redraw()
 
-			setTimeout(function() {
-				o(root.childNodes.length).equals(1)
-				o(root.firstChild.nodeName).equals("DIV")
+						o(count).equals(2)
 
-				done()
-			}, FRAME_BUDGET)
-		})
-		o("m.route.get", function(done) {
-			var root = window.document.createElement("div")
-			m.route(root, "/a", {
-				"/a": {view: function() {return m("div")}}
+						done()
+					}, FRAME_BUDGET)
+				})
 			})
-
-			setTimeout(function() {
-				o(m.route.get()).equals("/a")
-
-				done()
-			}, FRAME_BUDGET)
-		})
-		o("m.route.set", function(done, timeout) {
-			timeout(100)
-			var root = window.document.createElement("div")
-			m.route(root, "/a", {
-				"/:id": {view: function() {return m("div")}}
-			})
-
-			setTimeout(function() {
-				m.route.set("/b")
-				setTimeout(function() {
-					o(m.route.get()).equals("/b")
-
-					done()
-				}, FRAME_BUDGET)
-			}, FRAME_BUDGET)
-		})
-	})
-	o.spec("m.redraw", function() {
-		o("works", function(done) {
-			var count = 0
-			var root = window.document.createElement("div")
-			m.mount(root, {view: function() {count++}})
-			setTimeout(function() {
-				m.redraw()
-
-				o(count).equals(2)
-
-				done()
-			}, FRAME_BUDGET)
 		})
 	})
 })


### PR DESCRIPTION
Edit: build failure due to flaky test timeout. 

Edit2: [review link with white space diff ignored](https://github.com/lhorie/mithril.js/pull/1643/files?w=1) Original follows.

This runs most component-related tests on POJO, closure and constructible components. I've left out the `api/router.js` tests because segregating test with and without components without losing the tests organisation was not obvious.

With each step but the last one and 90b67b4 the total number of assertions remains identical.

For posterity, here's the jscodeshift script used to wrap some of the components:

```JS
module.exports = (file, api) => {
    var j = api.jscodeshift,
        s = api.stats;

    return j(file.source)
        .find(j.VariableDeclarator, {
            id : {name : "component"}
        })
        .forEach(() => {
            s("component")
        })
        .replaceWith((p) => j.template.expression`
            component = createComponent(${p.get("init").value})
        `)
        .toSource();
};
```

Using @tivac's mithril-codemods (`m.module => m.mount`) as template.

I'll build the #1638 and #1641 fixes on top of this.