### PR TITLE
When method is GET and TRACE, useBody becomes always false

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -43,7 +43,7 @@ module.exports = function($window, Promise) {
 			if (args.method == null) args.method = "GET"
 			args.method = args.method.toUpperCase()
 
-			var useBody = typeof args.useBody === "boolean" ? args.useBody : args.method !== "GET" && args.method !== "TRACE"
+			var useBody = (args.method === "GET" || args.method === "TRACE") ? false : (typeof args.useBody === "boolean" ? args.useBody : true)
 
 			if (typeof args.serialize !== "function") args.serialize = typeof FormData !== "undefined" && args.data instanceof FormData ? function(value) {return value} : JSON.stringify
 			if (typeof args.deserialize !== "function") args.deserialize = deserialize


### PR DESCRIPTION
m.request's document says

```
Force the use of the HTTP body section for data in GET requests when set to true.
```

But body may have any contents with GET request and server should ignore it:

http://stackoverflow.com/questions/5725430/http-test-server-that-accepts-get-post-calls

And MDN says the body is completely ignored when the method is GET or HEAD.
And I tried on Chrome, the server doesn't receive any bodies even if ```useBody: true```.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send

My extra concern:

* Should I add "HEAD" to the condition?