### PR TITLE
Fix todomvc state.update and ui.save

### DIFF
--- a/examples/todomvc/todomvc.js
+++ b/examples/todomvc/todomvc.js
@@ -38,7 +38,7 @@ var state = {
 	update: function(title) {
 		if (state.editing != null) {
 			state.editing.title = title.trim()
-			if (state.editing.title === "") destroy(state.editing)
+			if (state.editing.title === "") state.destroy(state.editing)
 			state.editing = null
 		}
 	},

--- a/examples/todomvc/todomvc.js
+++ b/examples/todomvc/todomvc.js
@@ -104,7 +104,7 @@ var Todos = {
 								m("label", {ondblclick: function() {state.dispatch("edit", [todo])}}, todo.title),
 								m("button.destroy", {onclick: function() {state.dispatch("destroy", [todo])}}),
 							]),
-							m("input.edit", {onupdate: function(vnode) {ui.focus(vnode, todo)}, onkeypress: ui.save, onblur: ui.save})
+							m("input.edit", {onupdate: function(vnode) {ui.focus(vnode, todo)}, onkeyup: ui.save, onblur: ui.save})
 						])
 					}),
 				]),


### PR DESCRIPTION
Expected behavior: When edit todo title. If press enter when title is blank. Todo item should delete
Observed behavior: Nothing happen when press enter.
Root Cause. state.update call to destroy instead of state.destroy()

Expected behavior: When edit todo title. If press escape, all change should cancel
Observed behavior: Nothing happen when press escape
Root Cause. input.edit monitor onkeypress event instead of onkeyup event

This PR fixes todomvc to work as expected.