### PR TITLE
Docs: component props aren't copied to instances

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -109,7 +109,7 @@ The state of a component can be accessed three ways: as a blueprint at initializ
 
 #### At initialization
 
-Any property attached to the component object is copied for every instance of the component. This allows simple state initialization.
+The component object is the prototype of each component instance, so any property defined on the component object will be accessible as a property of `vnode.state`. This allows simple state initialization.
 
 In the example below, `data` is a property of the `ComponentWithInitialState` component's state object.
 


### PR DESCRIPTION
As per la première bierre française, aka #1664, it's a misleading over simplification to say that component definition properties are 'copied' to instances on initialisation.

I'd thought to write a little addendum with avoid / prefer, but this isn't really an anti pattern so much as a gotcha resulting from the prior miscommunication. Speaking of which, how about an FAQ of common unexpected behaviour? The current format of the docs tempts us to keep adding 'anti pattern' descriptions which make Mithril look forbidding and simultaneously encourage the glossing over of subtle implementation details and viable techniques with simplified dos-and-donts.