### PR TITLE
IICE => IIFE

### DIFF
--- a/bundler/bundle.js
+++ b/bundler/bundle.js
@@ -114,7 +114,7 @@ function run(input, output) {
 			.replace(/(\r|\n)+/g, "\n").replace(/(\r|\n)$/, "") // remove multiline breaks
 			.replace(versionTag, isFile(packageFile) ? parse(packageFile).version : versionTag) // set version
 		
-		code = "new function() {\n" + code + "\n}"
+		code = ";(function() {\n" + code + "\n}());"
 		
 		if (!isFile(output) || code !== read(output)) {
 			//try {new Function(code); console.log("build completed at " + new Date())} catch (e) {}

--- a/bundler/tests/test-bundler.js
+++ b/bundler/tests/test-bundler.js
@@ -21,8 +21,7 @@ o.spec("bundler", function() {
 		write("a.js", `var b = require("./b")`)
 		write("b.js", `module.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
-		
-		o(read("out.js")).equals(`new function() {\nvar b = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -33,7 +32,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = 1;`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b = 1;\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b = 1;\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -44,7 +43,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nlet b = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\nlet b = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -55,7 +54,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nconst b = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\nconst b = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -66,7 +65,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar a = {}\na.b = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar a = {}\na.b = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -77,7 +76,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b = {}\nb = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b = {}\nb = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -88,7 +87,7 @@ o.spec("bundler", function() {
 		write("b.js", `"use strict"\nmodule.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\n"use strict"\nvar b = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\n"use strict"\nvar b = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -99,7 +98,7 @@ o.spec("bundler", function() {
 		write("b.js", `'use strict'\nmodule.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\n'use strict'\nvar b = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\n'use strict'\nvar b = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -110,7 +109,7 @@ o.spec("bundler", function() {
 		write("b.js", `'use strict'\nmodule.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\n"use strict"\nvar b = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\n"use strict"\nvar b = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -121,7 +120,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = function() {return a}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nwindow.a = 1\nvar b = function() {return a}\n}`)
+		o(read("out.js")).equals(`;(function() {\nwindow.a = 1\nvar b = function() {return a}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -132,7 +131,7 @@ o.spec("bundler", function() {
 		write("b.js", `1 + 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\n1 + 1\n}`)
+		o(read("out.js")).equals(`;(function() {\n1 + 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -143,7 +142,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = []`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar _0 = []\nvar b = _0.toString()\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar _0 = []\nvar b = _0.toString()\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -154,7 +153,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = []`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar _0 = []\nvar b = _0\n\t.toString()\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar _0 = []\nvar b = _0\n\t.toString()\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -165,7 +164,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = function() {}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar _0 = function() {}\nvar b = _0()\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar _0 = function() {}\nvar b = _0()\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -176,7 +175,7 @@ o.spec("bundler", function() {
 		write("b.js", `module.exports = function() {}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar _0 = function() {}\nvar b = _0\n()\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar _0 = function() {}\nvar b = _0\n()\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -188,7 +187,7 @@ o.spec("bundler", function() {
 		write("c.js", `var b = require("./b")\nmodule.exports = function() {return b}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar _0 = []\nvar b = _0.toString()\nvar b0 = _0\nvar c = function() {return b0}\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar _0 = []\nvar b = _0.toString()\nvar b0 = _0\nvar c = function() {return b0}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -201,7 +200,7 @@ o.spec("bundler", function() {
 		write("c.js", `var x\nmodule.exports = 2`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b = 1\nvar x\nvar c = 2\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b = 1\nvar x\nvar c = 2\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -214,7 +213,7 @@ o.spec("bundler", function() {
 		write("c.js", `var cc = 2\nmodule.exports = cc`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar x = {}\nvar bb = 1\nx.b = bb\nvar cc = 2\nx.c = cc\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar x = {}\nvar bb = 1\nx.b = bb\nvar cc = 2\nx.c = cc\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -227,7 +226,7 @@ o.spec("bundler", function() {
 		write("c.js", `var cc = 2\nmodule.exports = cc`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar x = {}\nvar bb = 1\nx["b"] = bb\nvar cc = 2\nx["c"] = cc\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar x = {}\nvar bb = 1\nx["b"] = bb\nvar cc = 2\nx["c"] = cc\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -239,7 +238,7 @@ o.spec("bundler", function() {
 		write("b.js", `var b = 1\nmodule.exports = 2`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b0 = 1\nvar b = 2\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b0 = 1\nvar b = 2\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -251,7 +250,7 @@ o.spec("bundler", function() {
 		write("c.js", `var b = {}\nmodule.exports = b`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b = {}\nb.x = 1\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b = {}\nb.x = 1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -265,7 +264,7 @@ o.spec("bundler", function() {
 		write("d.js", `var a = 3\nmodule.exports = a`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar a = 1\nvar b = a\nvar a0 = 2\nvar c = a0\nvar a1 = 3\nvar d = a1\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar a = 1\nvar b = a\nvar a0 = 2\nvar c = a0\nvar a1 = 3\nvar d = a1\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -279,7 +278,7 @@ o.spec("bundler", function() {
 		write("c.js", `var a = require("./a").toString()\nvar b = require("./b")`)
 		bundle(ns + "c.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar _0 = 123\nvar a = _0.toString()\nvar a0 = _0.toString()\nvar b = a0\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar _0 = 123\nvar a = _0.toString()\nvar a0 = _0.toString()\nvar b = a0\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -291,7 +290,7 @@ o.spec("bundler", function() {
 		write("c.js", `var b = require("./b")\nvar a = require("./a").toString()`)
 		bundle(ns + "c.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar _0 = 123\nvar a0 = _0.toString()\nvar b = a0\nvar a = _0.toString()\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar _0 = 123\nvar a0 = _0.toString()\nvar b = a0\nvar a = _0.toString()\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -304,7 +303,7 @@ o.spec("bundler", function() {
 		write("d.js", `module.exports = 1`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar d = 1\nvar b = function() {return d + 1}\nvar c = function() {return d + 2}\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar d = 1\nvar b = function() {return d + 1}\nvar c = function() {return d + 2}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -317,7 +316,7 @@ o.spec("bundler", function() {
 		write("b.js", `var b = 1\nmodule.exports = function() {return b}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b0 = 1\nvar b = function() {return b0}\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b0 = 1\nvar b = function() {return b0}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -328,7 +327,7 @@ o.spec("bundler", function() {
 		write("b.js", `var a = 2\nmodule.exports = function() {return a}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar a = 1\nvar a0 = 2\nvar b = function() {return a0}\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar a = 1\nvar a0 = 2\nvar b = function() {return a0}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -339,7 +338,7 @@ o.spec("bundler", function() {
 		write("b.js", `var a = 2\nmodule.exports = function() {return a}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nfunction a() {}\nvar a0 = 2\nvar b = function() {return a0}\n}`)
+		o(read("out.js")).equals(`;(function() {\nfunction a() {}\nvar a0 = 2\nvar b = function() {return a0}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -351,7 +350,7 @@ o.spec("bundler", function() {
 		write("c.js", `var a = 2\nmodule.exports = function() {return a}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar a = 1\nvar b = function() {return a}\nvar a0 = 2\nvar c = function() {return a0}\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar a = 1\nvar b = function() {return a}\nvar a0 = 2\nvar c = function() {return a0}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -363,7 +362,7 @@ o.spec("bundler", function() {
 		write("b.js", `var b = "b b b \\\" b"\nmodule.exports = function() {return b}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b0 = "b b b \\\" b"\nvar b = function() {return b0}\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b0 = "b b b \\\" b"\nvar b = function() {return b0}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")
@@ -374,7 +373,7 @@ o.spec("bundler", function() {
 		write("b.js", `var b = {b: 1}\nmodule.exports = function() {return b.b}`)
 		bundle(ns + "a.js", ns + "out.js")
 		
-		o(read("out.js")).equals(`new function() {\nvar b0 = {b: 1}\nvar b = function() {return b0.b}\n}`)
+		o(read("out.js")).equals(`;(function() {\nvar b0 = {b: 1}\nvar b = function() {return b0.b}\n}());`)
 		
 		remove("a.js")
 		remove("b.js")

--- a/stream/stream.js
+++ b/stream/stream.js
@@ -1,6 +1,6 @@
 "use strict"
 
-new function() {
+;(function() {
 
 var guid = 0, HALT = {}
 function createStream() {
@@ -118,4 +118,4 @@ if (typeof module !== "undefined") module["exports"] = createStream
 else if (typeof window.m === "function" && !("stream" in window.m)) window.m.stream = createStream
 else window.m = {stream : createStream}
 
-}
+}());


### PR DESCRIPTION
#### Abastract

Building on @nolanlawson's work on [optimize-js](https://github.com/nolanlawson/optimize-js), we measured the Mithril loading times with different types of module wrappers.

#### Methods:

The following contenders were evaluated:

- IICE `new function(){}`, where C stands for constructor, the current Mithril wrapper
- IIFE `(function(){}())`, the Crockford-sanctioned syntax.
- BIIFE `!function{}()` where B stands for Bang, popular among punks (and robots?)

Performance was [measured](http://jsbin.com/kizasekuho/1/edit?html,js,output) with `window.performance.now()` (with a fallback to Date.now() for iOS Safari). We used a "three scripts tags per measure" approach to really measure the parse time of the middle one.

```HTML
<script>var start = now()</script>
<script>var iteration = $iterationCountAsANumberLiteralReally; /* Mithril source here*/</script>
<script>results[kindOfWrapper].push(now()-start)</script>
```

Loading order was randomized, and a nonce was added to the beginning of each sample to bust potential parser caches. Code was added to ensure that the script tags loaded in their insertion order (since we knew remote scripts could be re-ordered when injected programmatically, and we didn't know how locally injected ones would work).

Benchmarks were run on a Mac, a Win10 laptop and a two years old Android phone. No iOS measurements were performed due to a lack of iDevices in our immediate vicinity.

Keeping up with scientific tradition, we went at some length to keep the benchmark code *ad hoc* and messy.

Each sample was run between 100 and 10000 times per browser depending on result stability (Firefox seemed less stable, with many tabs loaded on our laptop — it is our primary browser).

#### Results (median absolute time, % of the fastest option in each environment):

          median(ms)  iife  biife   iice |% iife   biife  iice
    -----------------------------------------------------------
    Chrome Mac      | 5.69 | 7.59 | 7.61 |   100 |  133 |  134
    Firefox Mac     | 2.53 | 2.62 | 2.56 |   100 |  104 |  101
    Safari Mac      | 2.38 | 2.65 | 2.68 |   100 |  111 |  113
    Chrome Win      | 5.51 | 7.83 | 7.71 |   100 |  142 |  140
    Firefox Win     | 5.05 | 5.31 | 5.03 |   100 |  106 |  100
    IE11 Win        | 2.89 | 3.66 | 2.90 |   100 |  127 |  100
    Edge Win        | 3.27 | 3.26 | 4.47 |   100 |  100 |  137
    Chrome Android  | 33.4 | 46.1 | 46.1 |   100 |  138 |  138
    Firefox Android | 15.4 | 16.0 | 15.4 |   100 |  104 |  100

#### Conclusion:

1) Google Chrome universally sucks at parsing JavaScript
2) The plain old `(function(){}())` IIFE is up to ~30% (`1 - ( 1 / 1.4 )`) faster than the other options, and up to 12ms faster at parsing Mithril on Chrome + Android. It is never slower than the alternatives. While it may not seem much, we remember reading that @lhorie uses the bundler for other projects where the larger file size may make a difference.