### PR TITLE
#1686: Updated TypeScript defs.

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -34,7 +34,7 @@ declare namespace Mithril {
 		/** Creates a virtual element (Vnode). */
 		<Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
 		/** Creates a fragment virtual element (Vnode). */
-		fragment(attrs: Lifecycle<any, any> & { [key: string]: any }, children: ChildArray | string | number | boolean): Vnode<any, any>;
+		fragment(attrs: Lifecycle<any, any> & { [key: string]: any }, children: ChildArrayOrPrimitive): Vnode<any, any>;
 		/** Turns an HTML string into a virtual element (Vnode). Do not use trust on unsanitized user input. */
 		trust(html: string): Vnode<any, any>;
 	}
@@ -212,6 +212,7 @@ declare namespace Mithril {
 	type Child = Vnode<any, any> | string | number | boolean | null | undefined;
 	interface ChildArray extends Array<Children> { }
 	type Children = Child | ChildArray;
+	type ChildArrayOrPrimitive = ChildArray | string | number | boolean;
 
 	/** Virtual DOM nodes, or vnodes, are Javascript objects that represent an element (or parts of the DOM). */
 	interface Vnode<Attrs, State extends Lifecycle<Attrs, State>> {
@@ -224,7 +225,7 @@ declare namespace Mithril {
 		/** The value used to map a DOM element to its respective item in an array of data. */
 		key?: string | number;
 		/** In most vnode types, the children property is an array of vnodes. For text and trusted HTML vnodes, The children property is either a string, a number or a boolean. */
-		children?: Children;
+		children?: ChildArrayOrPrimitive;
 		/** This is used instead of children if a vnode contains a text node as its only child. This is done for performance reasons. Component vnodes never use the text property even if they have a text node as their only child. */
 		text?: string | number | boolean;
 	}

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -19,7 +19,7 @@ declare namespace Mithril {
 		/** The onupdate hook is called after a DOM element is updated, while attached to the document. */
 		onremove?: (this: State, vnode: VnodeDOM<Attrs, State>) => any;
 		/** The onbeforeremove hook is called before a DOM element is detached from the document. If a Promise is returned, Mithril only detaches the DOM element after the promise completes. */
-		onbeforeupdate?: (this: State, vnode: Vnode<Attrs, State>, old: Vnode<Attrs, State>) => boolean | void;
+		onbeforeupdate?: (this: State, vnode: VnodeDOM<Attrs, State>, old: VnodeDOM<Attrs, State>) => boolean | void;
 		/** The onremove hook is called before a DOM element is removed from the document. */
 		onupdate?: (this: State, vnode: VnodeDOM<Attrs, State>) => any;
 	}

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -1,55 +1,69 @@
-// Type definitions for mithril.js 1.0
-// Project: https://github.com/lhorie/mithril.js
-// Definitions by: Mike Linkovich <https://github.com/spacejack>
+// Type definitions for Mithril 1.0
+// Project: http://lhorie.github.io/mithril/
+// Definitions by: Leo Horie <https://github.com/lhorie>, Chris Bowdon <https://github.com/cbowdon>, Mike Linkovich <https://github.com/spacejack>, András Parditka <https://github.com/andraaspar>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Mithril type definitions for Typescript 2
 
 declare namespace Mithril {
 
-	interface Lifecycle<A,S> {
+	interface Lifecycle<Attrs, State> {
+		/** Any property attached to the component object is copied for every instance of the component. This allows simple state initialization. */
+		[propName: string]: any;
 		/** The oninit hook is called before a vnode is touched by the virtual DOM engine. */
-		oninit?: (this: S, vnode: Vnode<A,S>) => void;
+		oninit?: (this: State, vnode: Vnode<Attrs, State>) => any;
 		/** The oncreate hook is called after a DOM element is created and attached to the document. */
-		oncreate?: (this: S, vnode: VnodeDOM<A,S>) => void;
+		oncreate?: (this: State, vnode: Vnode<Attrs, State>) => any;
 		/** The onbeforeupdate hook is called before a vnode is diffed in a update. */
-		onbeforeupdate?: (this: S, vnode: Vnode<A,S>, old: Vnode<A,S>) => boolean;
+		onbeforeremove?: (this: State, vnode: Vnode<Attrs, State>) => Promise<any> | void;
 		/** The onupdate hook is called after a DOM element is updated, while attached to the document. */
-		onupdate?: (this: S, vnode: VnodeDOM<A,S>) => void;
+		onremove?: (this: State, vnode: Vnode<Attrs, State>) => any;
 		/** The onbeforeremove hook is called before a DOM element is detached from the document. If a Promise is returned, Mithril only detaches the DOM element after the promise completes. */
-		onbeforeremove?: (this: S, vnode: VnodeDOM<A,S>) => Promise<any> | void;
+		onbeforeupdate?: (this: State, vnode: Vnode<Attrs, State>, old: Vnode<Attrs, State>) => boolean | void;
 		/** The onremove hook is called before a DOM element is removed from the document. */
-		onremove?: (this: S, vnode: VnodeDOM<A,S>) => void;
+		onupdate?: (this: State, vnode: Vnode<Attrs, State>) => any;
 	}
 
 	interface Hyperscript {
 		/** Creates a virtual element (Vnode). */
-		(selector: string, ...children: any[]): Vnode<any,any>;
+		(selector: string, ...children: Children[]): Vnode<any, any>;
 		/** Creates a virtual element (Vnode). */
-		<A,S>(component: Component<A,S> | {new(vnode: CVnode<A>): ClassComponent<A>} | FactoryComponent<A,S>, a?: (A & Lifecycle<A,S>) | Children, ...children: Children[]): Vnode<A,S>;
+		(selector: string, attributes: Attributes, ...children: Children[]): Vnode<any, any>;
+		/** Creates a virtual element (Vnode). */
+		<Attrs, State>(component: ComponentTypes<Attrs, State>, attributes: Attrs & Lifecycle<Attrs, State> & { key?: string | number }, ...args: Children[]): Vnode<Attrs, State>;
+		/** Creates a virtual element (Vnode). */
+		<Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
 		/** Creates a fragment virtual element (Vnode). */
-		fragment(attrs: any, children: Children[]): Vnode<any,any>;
+		fragment(attrs: Lifecycle<any, any> & { [key: string]: any }, children: Children): Vnode<any, any>;
 		/** Turns an HTML string into a virtual element (Vnode). Do not use trust on unsanitized user input. */
-		trust(html: string): Vnode<any,any>;
+		trust(html: string): Vnode<any, any>;
 	}
 
-	interface RouteResolver {
+	interface RouteResolver<State, Params> {
 		/** The onmatch hook is called when the router needs to find a component to render. */
-		onmatch?: (args: any, requestedPath: string) => Mithril.Component<any,any> | {new(vnode: CVnode<any>): ClassComponent<any>} | FactoryComponent<any,any> | Promise<Mithril.Component<any,any> | {new(): Component<any,any>} | FactoryComponent<any,any>> | void;
+		render?: (this: State, vnode: Vnode<State, Params>) => Children;
 		/** The render method is called on every redraw for a matching route. */
-		render?: (vnode: Mithril.Vnode<any,any>) => Children;
+		onmatch?: (args: Params, requestedPath: string) => Component<any, any> | Promise<Component<any, any>> | void;
 	}
 
+	/** This represents a key-value mapping linking routes to components. */
 	interface RouteDefs {
-		[url: string]: Component<any,any> | {new(vnode: CVnode<any>): ClassComponent<any>} | FactoryComponent<any,any> | RouteResolver;
+		/** The key represents the route. The value represents the corresponding component. */
+		[url: string]: ComponentTypes<any, any> | RouteResolver<any, any>;
 	}
 
 	interface RouteOptions {
+		/** Routing parameters. If path has routing parameter slots, the properties of this object are interpolated into the path string. */
 		replace?: boolean;
+		/** The state object to pass to the underlying history.pushState / history.replaceState call.*/
 		state?: any;
+		/** The title string to pass to the underlying history.pushState / history.replaceState call. */
 		title?: string;
 	}
 
 	interface Route {
 		/** Creates application routes and mounts Components and/or RouteResolvers to a DOM element. */
-		(element: HTMLElement, defaultRoute: string, routes: RouteDefs): void;
+		(element: Element, defaultRoute: string, routes: RouteDefs): void;
 		/** Returns the last fully resolved routing path, without the prefix. */
 		get(): string;
 		/** Redirects to a matching route or to the default route if no matching routes can be found. */
@@ -57,49 +71,66 @@ declare namespace Mithril {
 		/** Defines a router prefix which is a fragment of the URL that dictates the underlying strategy used by the router. */
 		prefix(urlFragment: string): void;
 		/** This method is meant to be used in conjunction with an <a> Vnode's oncreate hook. */
-		link(vnode: Vnode<any,any>): (e: Event) => void;
+		link(vnode: Vnode<any, any>): (e?: Event) => any;
 		/** Returns the named parameter value from the current route. */
-		param(name?: string): any;
+		param(name: string): string;
+		/** Gets all route parameters. */
+		param(): any;
 	}
 
 	interface Mount {
 		/** Mounts a component to a DOM element, enabling it to autoredraw on user events. */
-		(element: Element, component: Component<any,any> | {new(vnode: CVnode<any>): ClassComponent<any>} | FactoryComponent<any,any> | null): void;
+		(element: Element, component: ComponentTypes<any, any> | null): void;
 	}
 
 	interface WithAttr {
 		/** Creates an event handler which takes the value of the specified DOM element property and calls a function with it as the argument. */
-		(name: string, callback: (value: any) => void, thisArg?: any): (e: {currentTarget: any, [p: string]: any}) => boolean;
+		(name: string, callback: (value: any) => any, thisArg?: any): (e: { currentTarget: any, [p: string]: any }) => void;
 	}
 
 	interface ParseQueryString {
 		/** Returns an object with key/value pairs parsed from a string of the form: ?a=1&b=2 */
-		(queryString: string): any;
+		(queryString: string): { [p: string]: any };
 	}
 
 	interface BuildQueryString {
 		/** Turns the key/value pairs of an object into a string of the form: a=1&b=2 */
-		(values: {[p: string]: any}): string;
+		(values: { [p: string]: any }): string;
 	}
 
 	interface RequestOptions<T> {
+		/** The HTTP method to use. */
 		method?: string;
+		/** The data to be interpolated into the URL and serialized into the querystring (for GET requests) or body (for other types of requests). */
 		data?: any;
+		/** Whether the request should be asynchronous. Defaults to true. */
 		async?: boolean;
+		/** A username for HTTP authorization. */
 		user?: string;
+		/** A password for HTTP authorization. */
 		password?: string;
+		/** Whether to send cookies to 3rd party domains. */
 		withCredentials?: boolean;
-		config?: (xhr: XMLHttpRequest) => void;
+		/** Exposes the underlying XMLHttpRequest object for low-level configuration. */
+		config?: (xhr: XMLHttpRequest) => any;
+		/** Headers to append to the request before sending it. */
 		headers?: any;
-		type?: any;
-		serialize?: (data: any) => string;
-		deserialize?: (str: string) => T;
+		/** A constructor to be applied to each object in the response. */
+		type?: new (o: any) => any;
+		/** A serialization method to be applied to data. Defaults to JSON.stringify, or if options.data is an instance of FormData, defaults to the identity function. */
+		serialize?: (data: any) => any;
+		/** A deserialization method to be applied to the response. Defaults to a small wrapper around JSON.parse that returns null for empty responses. */
+		deserialize?: (data: any) => T;
+		/** A hook to specify how the XMLHttpRequest response should be read. Useful for reading response headers and cookies. Defaults to a function that returns xhr.responseText */
 		extract?: (xhr: XMLHttpRequest, options: RequestOptions<T>) => string;
+		/** Force the use of the HTTP body section for data in GET requests when set to true, or the use of querystring for other HTTP methods when set to false. Defaults to false for GET requests and true for other methods. */
 		useBody?: boolean;
+		/** If false, redraws mounted components upon completion of the request. If true, it does not. */
 		background?: boolean;
 	}
 
 	interface RequestOptionsAll<T> extends RequestOptions<T> {
+		/** The URL to send the request to. */
 		url: string;
 	}
 
@@ -111,14 +142,20 @@ declare namespace Mithril {
 	}
 
 	interface JsonpOptions {
+		/** The data to be interpolated into the URL and serialized into the querystring. */
 		data?: any;
-		type?: any;
+		/** A constructor to be applied to each object in the response. */
+		type?: new (o: any) => any;
+		/** The name of the function that will be called as the callback. */
 		callbackName?: string;
+		/** The name of the querystring parameter name that specifies the callback name. */
 		callbackKey?: string;
+		/** If false, redraws mounted components upon completion of the request. If true, it does not. */
 		background?: boolean;
 	}
 
 	interface JsonpOptionsAll extends JsonpOptions {
+		/** The URL to send the request to. */
 		url: string;
 	}
 
@@ -155,57 +192,72 @@ declare namespace Mithril {
 
 	interface Static extends Hyperscript {
 		route: Route;
+		/** Activates a component, enabling it to autoredraw on user events. */
 		mount: Mount;
+		/** Returns a event handler that can be bound to an element, firing with the specified property. */
 		withAttr: WithAttr;
 		render: Render;
 		redraw: Redraw;
 		request: Request;
 		jsonp: Jsonp;
+		/** Parse a query string into an object. */
 		parseQueryString: ParseQueryString;
+		/** Serialize an object into a query string. */
 		buildQueryString: BuildQueryString;
+		/** A string containing the semver value for the current Mithril release. */
 		version: string;
 	}
 
 	// Vnode children types
-	type Child = Vnode<any,any> | string | number | boolean | null | undefined;
-	interface ChildArray extends Array<Children> {}
+	type Child = Vnode<any, any> | string | number | boolean | null | undefined;
+	interface ChildArray extends Array<Children> { }
 	type Children = Child | ChildArray;
 
-	interface Vnode<A, S extends Lifecycle<A,S>> {
-		tag: string | Component<A,S>;
-		attrs: A;
-		state: S;
-		key?: string;
-		children?: Vnode<any,any>[];
-		events?: any;
-	}
-
-	// In some lifecycle methods, Vnode will have a dom property
-	// and possibly a domSize property.
-	interface VnodeDOM<A,S> extends Vnode<A,S> {
-		dom: Element;
+	/** Virtual DOM nodes, or vnodes, are Javascript objects that represent an element (or parts of the DOM). */
+	interface Vnode<Attrs, State extends Lifecycle<Attrs, State>> {
+		/** The nodeName of a DOM element. It may also be the string [ if a vnode is a fragment, # if it's a text vnode, or < if it's a trusted HTML vnode. Additionally, it may be a component. */
+		tag: string | Component<Attrs, State>;
+		/** A hashmap of DOM attributes, events, properties and lifecycle methods. */
+		attrs: Attrs;
+		/** An object that is persisted between redraws. In component vnodes, state is a shallow clone of the component object. */
+		state: State;
+		/** The value used to map a DOM element to its respective item in an array of data. */
+		key?: string | number;
+		/** In most vnode types, the children property is an array of vnodes. For text and trusted HTML vnodes, The children property is either a string, a number or a boolean. */
+		children?: Children;
+		/** This is used instead of children if a vnode contains a text node as its only child. This is done for performance reasons. Component vnodes never use the text property even if they have a text node as their only child. */
+		text?: string | number | boolean;
+		/** Points to the element that corresponds to the vnode. */
+		dom?: Element;
+		/** This defines the number of DOM elements that the vnode represents (starting from the element referenced by the dom property). */
 		domSize?: number;
 	}
 
-	interface CVnode<A> extends Vnode<A, ClassComponent<A>> {}
+	interface CVnode<A> extends Vnode<A, ClassComponent<A>> { }
 
-	interface CVnodeDOM<A> extends VnodeDOM<A, ClassComponent<A>> {}
+	/** Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse. Any Javascript object that has a view method is a Mithril component. Components can be consumed via the m() utility. */
+	interface Component<Attrs, State extends Lifecycle<Attrs, State>> extends Lifecycle<Attrs, State> {
 
-	interface Component<A, S extends Lifecycle<A,S>> extends Lifecycle<A,S> {
-		view (this: S, vnode: Vnode<A,S>): Vnode<any,any> | null | void | (Vnode<any,any> | null | void)[];
+		/** Creates a view out of virtual elements. */
+		view(this: State, vnode: Vnode<Attrs, State>): Children | null | void;
 	}
 
-	interface ClassComponent<A> extends Lifecycle<A,ClassComponent<A>> {
-		view (this: ClassComponent<A>, vnode: CVnode<A>): Vnode<any,any> | null | void | (Vnode<any,any> | null | void)[];
+	interface ClassComponent<A> extends Lifecycle<A, ClassComponent<A>> {
+		view(this: ClassComponent<A>, vnode: CVnode<A>): Children | null | void;
 	}
 
 	// Factory component
-	type FactoryComponent<A,S> = (vnode: Vnode<A,S>) => Component<A,S>
+	type FactoryComponent<A, S> = (vnode: Vnode<A, S>) => Component<A, S>
 
-	type Unary<T,U> = (input: T) => U;
+	/** Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse. Any Javascript object that has a view method is a Mithril component. Components can be consumed via the m() utility. */
+	type Comp<Attrs, State extends Lifecycle<Attrs, State>> = Component<Attrs, State> & State;
+
+	type ComponentTypes<A, S> = Component<A, S> | { new (vnode: CVnode<A>): ClassComponent<A> } | FactoryComponent<A, S>
+
+	type Unary<T, U> = (input: T) => U;
 
 	interface Functor<T> {
-		map<U>(f: Unary<T,U>): Functor<U>;
+		map<U>(f: Unary<T, U>): Functor<U>;
 		ap?(f: Functor<T>): Functor<T>;
 	}
 
@@ -224,33 +276,52 @@ declare namespace Mithril {
 		ap<U>(f: Stream<(value: T) => U>): Stream<U>;
 		/** A co-dependent stream that unregisters dependent streams when set to true. */
 		end: Stream<boolean>;
+		/** When a stream is passed as the argument to JSON.stringify(), the value of the stream is serialized.*/
+		toJSON(): string;
+		/** Returns the value of the stream. */
+		valueOf(): T;
 	}
 
-	type StreamCombiner<T> = (...streams: any[]) => T
+	type StreamCombiner<T> = (...streams: any[]) => T;
 
 	interface StreamFactory {
 		/** Creates a stream. */
-		<T>(val?: T): Stream<T>;
+		<T>(value?: T): Stream<T>;
 		/** Creates a computed stream that reactively updates if any of its upstreams are updated. */
 		combine<T>(combiner: StreamCombiner<T>, streams: Stream<any>[]): Stream<T>;
 		/** Creates a stream whose value is the array of values from an array of streams. */
 		merge(streams: Stream<any>[]): Stream<any[]>;
 		/** A special value that can be returned to stream callbacks to halt execution of downstreams. */
-		HALT: any;
+		readonly HALT: any;
 	}
 
 	interface StreamScan {
 		/** Creates a new stream with the results of calling the function on every incoming stream with and accumulator and the incoming value. */
-		<T,U>(fn: (acc: U, value: T) => U, acc: U, stream: Stream<T>): Stream<U>;
+		<T, U>(fn: (acc: U, value: T) => U, acc: U, stream: Stream<T>): Stream<U>;
 	}
 
 	interface StreamScanMerge {
 		/** Takes an array of pairs of streams and scan functions and merges all those streams using the given functions into a single stream. */
-		<T,U>(pairs: [Stream<T>, (acc: U, value: T) => U][], acc: U): Stream<U>;
+		<T, U>(pairs: [Stream<T>, (acc: U, value: T) => U][], acc: U): Stream<U>;
 		/** Takes an array of pairs of streams and scan functions and merges all those streams using the given functions into a single stream. */
 		<U>(pairs: [Stream<any>, (acc: U, value: any) => U][], acc: U): Stream<U>;
 	}
+
+	/** This represents the attributes available for configuring virtual elements, beyond the applicable DOM attributes.*/
+	interface Attributes {
+		/** The class name(s) for this virtual element, as a space-separated list. */
+		className?: string;
+		/** The class name(s) for this virtual element, as a space-separated list. */
+		class?: string;
+		/** A key to optionally associate with this element. */
+		key?: string | number;
+		/** Any other virtual element properties, including attributes and event handlers. */
+		[property: string]: any;
+	}
 }
+
+declare const m: Mithril.Static;
+declare const stream: Mithril.StreamFactory;
 
 declare module 'mithril' {
 	const m: Mithril.Static;

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -19,7 +19,7 @@ declare namespace Mithril {
 		/** The onupdate hook is called after a DOM element is updated, while attached to the document. */
 		onremove?: (this: State, vnode: VnodeDOM<Attrs, State>) => any;
 		/** The onbeforeremove hook is called before a DOM element is detached from the document. If a Promise is returned, Mithril only detaches the DOM element after the promise completes. */
-		onbeforeupdate?: (this: State, vnode: VnodeDOM<Attrs, State>, old: VnodeDOM<Attrs, State>) => boolean | void;
+		onbeforeupdate?: (this: State, vnode: Vnode<Attrs, State>, old: VnodeDOM<Attrs, State>) => boolean | void;
 		/** The onremove hook is called before a DOM element is removed from the document. */
 		onupdate?: (this: State, vnode: VnodeDOM<Attrs, State>) => any;
 	}

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -318,7 +318,7 @@ declare namespace Mithril {
 	}
 
 	/** This represents the attributes available for configuring virtual elements, beyond the applicable DOM attributes.*/
-	interface Attributes {
+	interface Attributes extends Lifecycle<any, any> {
 		/** The class name(s) for this virtual element, as a space-separated list. */
 		className?: string;
 		/** The class name(s) for this virtual element, as a space-separated list. */

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -34,7 +34,7 @@ declare namespace Mithril {
 		/** Creates a virtual element (Vnode). */
 		<Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
 		/** Creates a fragment virtual element (Vnode). */
-		fragment(attrs: Lifecycle<any, any> & { [key: string]: any }, children: Children): Vnode<any, any>;
+		fragment(attrs: Lifecycle<any, any> & { [key: string]: any }, children: ChildArray | string | number | boolean): Vnode<any, any>;
 		/** Turns an HTML string into a virtual element (Vnode). Do not use trust on unsanitized user input. */
 		trust(html: string): Vnode<any, any>;
 	}

--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -13,15 +13,15 @@ declare namespace Mithril {
 		/** The oninit hook is called before a vnode is touched by the virtual DOM engine. */
 		oninit?: (this: State, vnode: Vnode<Attrs, State>) => any;
 		/** The oncreate hook is called after a DOM element is created and attached to the document. */
-		oncreate?: (this: State, vnode: Vnode<Attrs, State>) => any;
+		oncreate?: (this: State, vnode: VnodeDOM<Attrs, State>) => any;
 		/** The onbeforeupdate hook is called before a vnode is diffed in a update. */
-		onbeforeremove?: (this: State, vnode: Vnode<Attrs, State>) => Promise<any> | void;
+		onbeforeremove?: (this: State, vnode: VnodeDOM<Attrs, State>) => Promise<any> | void;
 		/** The onupdate hook is called after a DOM element is updated, while attached to the document. */
-		onremove?: (this: State, vnode: Vnode<Attrs, State>) => any;
+		onremove?: (this: State, vnode: VnodeDOM<Attrs, State>) => any;
 		/** The onbeforeremove hook is called before a DOM element is detached from the document. If a Promise is returned, Mithril only detaches the DOM element after the promise completes. */
 		onbeforeupdate?: (this: State, vnode: Vnode<Attrs, State>, old: Vnode<Attrs, State>) => boolean | void;
 		/** The onremove hook is called before a DOM element is removed from the document. */
-		onupdate?: (this: State, vnode: Vnode<Attrs, State>) => any;
+		onupdate?: (this: State, vnode: VnodeDOM<Attrs, State>) => any;
 	}
 
 	interface Hyperscript {
@@ -227,13 +227,22 @@ declare namespace Mithril {
 		children?: Children;
 		/** This is used instead of children if a vnode contains a text node as its only child. This is done for performance reasons. Component vnodes never use the text property even if they have a text node as their only child. */
 		text?: string | number | boolean;
+	}
+
+	// In some lifecycle methods, Vnode will have a dom property
+	// and possibly a domSize property.
+	interface VnodeDOM<Attrs, State> extends Vnode<Attrs, State> {
+
 		/** Points to the element that corresponds to the vnode. */
-		dom?: Element;
+		dom: Element;
+
 		/** This defines the number of DOM elements that the vnode represents (starting from the element referenced by the dom property). */
 		domSize?: number;
 	}
 
 	interface CVnode<A> extends Vnode<A, ClassComponent<A>> { }
+
+	interface CVnodeDOM<A> extends VnodeDOM<A, ClassComponent<A>> { }
 
 	/** Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse. Any Javascript object that has a view method is a Mithril component. Components can be consumed via the m() utility. */
 	interface Component<Attrs, State extends Lifecycle<Attrs, State>> extends Lifecycle<Attrs, State> {

--- a/tests/test-typings.ts
+++ b/tests/test-typings.ts
@@ -1,0 +1,626 @@
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/hyperscript.html#components
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+
+	// define a component
+	var Greeter: Mithril.Comp<{}, {}> = {
+		view: function(vnode) {
+			return m("div", vnode.attrs, ["Hello ", vnode.children])
+		}
+	}
+
+	// consume it
+	m(Greeter, { style: "color:red;" }, "world")
+	
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/hyperscript.html#keys
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+
+	var users = [
+		{ id: 1, name: "John" },
+		{ id: 2, name: "Mary" },
+	]
+
+	function userInputs(users: { id: number, name: string }[]) {
+		return users.map(function(u) {
+			return m("input", { key: u.id }, u.name)
+		})
+	}
+
+	m.render(document.body, userInputs(users))
+	
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/components.html#state
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var ComponentWithInitialState: Mithril.Comp<{}, {data: string}> = {
+		data: "Initial content",
+		view: function(vnode) {
+			return m("div", vnode.state.data)
+		}
+	}
+
+	m(ComponentWithInitialState)
+})
+
+;(function() {
+	var ComponentWithDynamicState: Mithril.Comp<{text: string}, {data?: string}> = {
+		oninit: function(vnode) {
+			vnode.state.data = vnode.attrs.text
+		},
+		view: function(vnode) {
+			return m("div", vnode.state.data)
+		}
+	}
+
+	m(ComponentWithDynamicState, { text: "Hello" })
+})
+
+;(function() {
+	var ComponentUsingThis: Mithril.Comp<{text: string}, {data?: string}> = {
+		oninit: function(vnode) {
+			this.data = vnode.attrs.text
+		},
+		view: function(vnode) {
+			return m("div", this.data)
+		}
+	}
+
+	m(ComponentUsingThis, { text: "Hello" })
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/lifecycle-methods.html
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var Fader: Mithril.Comp<{}, {}> = {
+		onbeforeremove: function(vnode) {
+			vnode.dom.classList.add("fade-out")
+			return new Promise(function(resolve) {
+				setTimeout(resolve, 1000)
+			})
+		},
+		view: function() {
+			return m("div", "Bye")
+		},
+	}
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/route.html#wrapping-a-layout-component
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	
+	var Home = {
+		view: function() {
+			return "Welcome"
+		}
+	}
+	
+	var state = {
+		term: "",
+		search: function() {
+			// save the state for this route
+			// this is equivalent to `history.replaceState({term: state.term}, null, location.href)`
+			m.route.set(m.route.get(), null, { replace: true, state: { term: state.term } })
+
+			// navigate away
+			location.href = "https://google.com/?q=" + state.term
+		}
+	}
+	
+	var Form: Mithril.Comp<{term: string}, {}> = {
+		oninit: function(vnode) {
+			state.term = vnode.attrs.term || "" // populated from the `history.state` property if the user presses the back button
+		},
+		view: function() {
+			return m("form", [
+				m("input[placeholder='Search']", { oninput: m.withAttr("value", function(v) { state.term = v }), value: state.term }),
+				m("button", { onclick: state.search }, "Search")
+			])
+		}
+	}
+	
+	var Layout: Mithril.Comp<{}, {}> = {
+		view: function(vnode) {
+			return m(".layout", vnode.children)
+		}
+	}
+	
+	// example 1
+	m.route(document.body, "/", {
+		"/": {
+			view: function() {
+				return m(Layout, m(Home))
+			},
+		},
+		"/form": {
+			view: function() {
+				return m(Layout, m(Form))
+			},
+		}
+	})
+	
+	// example 2
+	m.route(document.body, "/", {
+		"/": {
+			render: function() {
+				return m(Layout, m(Home))
+			},
+		},
+		"/form": {
+			render: function() {
+				return m(Layout, m(Form))
+			},
+		}
+	})
+	
+	// functionally equivalent to example 1
+	var Anon1 = {
+		view: function() {
+			return m(Layout, m(Home))
+		},
+	}
+	var Anon2 = {
+		view: function() {
+			return m(Layout, m(Form))
+		},
+	}
+
+	m.route(document.body, "/", {
+		"/": {
+			render: function() {
+				return m(Anon1)
+			}
+		},
+		"/form": {
+			render: function() {
+				return m(Anon2)
+			}
+		},
+	})
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/route.html#preloading-data
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var state = {
+		users: <any[]>[],
+		loadUsers: function() {
+			return m.request<any>("/api/v1/users").then(function(users) {
+				state.users = users
+			})
+		}
+	}
+
+	m.route(document.body, "/user/list", {
+		"/user/list": {
+			onmatch: state.loadUsers,
+			render: function() {
+				return state.users.map(function(user) {
+					return m("div", user.id)
+				})
+			}
+		},
+	})
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/request.html#monitoring-progress
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var progress = 0
+
+	m.mount(document.body, {
+		view: function() {
+			return [
+				m("input[type=file]", { onchange: upload }),
+				progress + "% completed"
+			]
+		}
+	})
+
+	function upload(e: Event) {
+		var file = (<FileList>(<HTMLInputElement>e.target).files)[0]
+
+		var data = new FormData()
+		data.append("myfile", file)
+
+		m.request({
+			method: "POST",
+			url: "/api/v1/upload",
+			data: data,
+			config: function(xhr) {
+				xhr.addEventListener("progress", function(e) {
+					progress = e.loaded / e.total
+
+					m.redraw() // tell Mithril that data changed and a re-render is needed
+				})
+			}
+		})
+	}
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/request.html#casting-response-to-a-type
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	
+	// Start rewrite to TypeScript
+	class User {
+		name: string;
+		constructor(data: any) {
+			this.name = data.firstName + " " + data.lastName
+		}
+	}
+	// End rewrite to TypeScript
+	
+	// function User(data) {
+	// 	this.name = data.firstName + " " + data.lastName
+	// }
+
+	m.request<User[]>({
+		method: "GET",
+		url: "/api/v1/users",
+		type: User
+	})
+	.then(function(users) {
+		console.log(users[0].name) // logs a name
+	})
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/request.html#non-json-responses
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	m.request<string>({
+		method: "GET",
+		url: "/files/icon.svg",
+		deserialize: function(value) { return value }
+	})
+	.then(function(svg) {
+		m.render(document.body, m.trust(svg))
+	})
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/jsonp.html
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	m.jsonp({
+		url: "/api/v1/users/:id",
+		data: { id: 1 },
+		callbackKey: "callback",
+	})
+	.then(function(result) {
+		console.log(result)
+	})
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/fragment.html
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var groupVisible = true
+	var log = function() {
+		console.log("group is now visible")
+	}
+
+	m("ul", [
+		m("li", "child 1"),
+		m("li", "child 2"),
+		groupVisible ? m.fragment({ oninit: log }, [
+			// a fragment containing two elements
+			m("li", "child 3"),
+			m("li", "child 4"),
+		]) : null
+	])
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/stream.html#computed-properties
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var firstName = stream("John")
+	var lastName = stream("Doe")
+	var fullName = stream.merge([firstName, lastName]).map(function(values) {
+		return values.join(" ")
+	})
+
+	console.log(fullName()) // logs "John Doe"
+
+	firstName("Mary")
+
+	console.log(fullName()) // logs "Mary Doe"
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/stream.html#chaining-streams
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var halted = stream(1).map(function(value) {
+		return stream.HALT
+	})
+
+	halted.map(function() {
+		// never runs
+	})
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/stream.html#combining-streams
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var a = stream(5)
+	var b = stream(7)
+
+	var added = stream.combine(function(a: Mithril.Stream<number>, b: Mithril.Stream<number>) {
+		return a() + b()
+	}, [a, b])
+
+	console.log(added()) // logs 12
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// http://mithril.js.org/stream.html#ended-state
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+	var value = stream<number>()
+	var doubled = value.map(function(value) { return value * 2 })
+
+	value.end(true) // set to ended state
+
+	value(5)
+
+	console.log(doubled())
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// https://github.com/lhorie/mithril.js/blob/master/examples/animation/mosaic.html
+////////////////////////////////////////////////////////////////////////////////
+
+// Excerpt
+
+;(function() {
+
+	var root = (<Element>document.getElementById("root"))
+
+	var empty: any[] = []
+	var full: any[] = []
+	for (var i = 0; i < 100; i++) full.push(i)
+
+	var cells: any[]
+
+	function view() {
+		return m(".container", cells.map(function(i) {
+			return m(".slice", {
+				style: {backgroundPosition: (i % 10 * 11) + "% " + (Math.floor(i / 10) * 11) + "%"},
+				onbeforeremove: exit
+			})
+		}))
+	}
+
+	function exit(vnode: Mithril.VnodeDOM<any, any>) {
+		vnode.dom.classList.add("exit")
+		return new Promise(function(resolve) {
+			setTimeout(resolve, 1000)
+		})
+	}
+
+	function run() {
+		cells = cells === full ? empty : full
+
+		m.render(root, [view()])
+
+		setTimeout(run, 2000)
+	}
+
+	run()
+
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// https://github.com/lhorie/mithril.js/blob/master/examples/editor/index.html
+////////////////////////////////////////////////////////////////////////////////
+
+// Excerpt
+
+;(function() {
+
+	// Start extra declarations
+	var marked = (v: string) => v
+	// End extra declarations
+
+	//model
+	var state = {
+		text: "# Markdown Editor\n\nType on the left panel and see the result on the right panel",
+		update: function(value: string) {
+			state.text = value
+		}
+	}
+
+	//view
+	var Editor = {
+		view: function() {
+			return [
+				m("textarea.input", {
+					oninput: m.withAttr("value", state.update),
+					value: state.text
+				}),
+				m(".preview", m.trust(marked(state.text))),
+			]
+		}
+	}
+
+	m.mount(<Element>document.getElementById("editor"), Editor)
+
+})
+
+////////////////////////////////////////////////////////////////////////////////
+// https://github.com/lhorie/mithril.js/blob/master/examples/todomvc/todomvc.js
+////////////////////////////////////////////////////////////////////////////////
+
+;(function() {
+
+	//model
+	var state = {
+		dispatch: function(action: string, args?: any) {
+			(<any>state)[action].apply(state, args || [])
+			requestAnimationFrame(function() {
+				localStorage["todos-mithril"] = JSON.stringify(state.todos)
+			})
+		},
+
+		todos: JSON.parse(localStorage["todos-mithril"] || "[]"),
+		editing: <any>null,
+		filter: "",
+		remaining: 0,
+		todosByStatus: <any>[],
+		showing: <string><any>undefined,
+
+		createTodo: function(title: string) {
+			state.todos.push({title: title.trim(), completed: false})
+		},
+		setStatuses: function(completed: boolean) {
+			for (var i = 0; i < state.todos.length; i++) state.todos[i].completed = completed
+		},
+		setStatus: function(todo: any, completed: boolean) {
+			todo.completed = completed
+		},
+		destroy: function(todo: any) {
+			var index = state.todos.indexOf(todo)
+			if (index > -1) state.todos.splice(index, 1)
+		},
+		clear: function() {
+			for (var i = 0; i < state.todos.length; i++) {
+				if (state.todos[i].completed) state.destroy(state.todos[i--])
+			}
+		},
+
+		edit: function(todo: any) {
+			state.editing = todo
+		},
+		update: function(title: string) {
+			if (state.editing != null) {
+				state.editing.title = title.trim()
+				if (state.editing.title === "") state.destroy(state.editing)
+				state.editing = null
+			}
+		},
+		reset: function() {
+			state.editing = null
+		},
+
+		computed: function(vnode: Mithril.Vnode<any, any>) {
+			state.showing = vnode.attrs.status || ""
+			state.remaining = state.todos.filter(function(todo: any) {return !todo.completed}).length
+			state.todosByStatus = state.todos.filter(function(todo: any) {
+				switch (state.showing) {
+					case "": return true
+					case "active": return !todo.completed
+					case "completed": return todo.completed
+				}
+			})
+		}
+	}
+
+	//view
+	var Todos: Mithril.Comp<{}, {
+		add(e: Event): void
+		toggleAll(): void
+		toggle(todo: any): void
+		focus(vnode: Mithril.VnodeDOM<any, any>, todo: any): void
+		save(e: KeyboardEvent): void
+	}> = {
+		add: function(e: KeyboardEvent) {
+			if (e.keyCode === 13) {
+				state.dispatch("createTodo", [(<HTMLInputElement>e.target).value]);
+				(<HTMLInputElement>e.target).value = ""
+			}
+		},
+		toggleAll: function() {
+			state.dispatch("setStatuses", [(<HTMLInputElement>document.getElementById("toggle-all")).checked])
+		},
+		toggle: function(todo: any) {
+			state.dispatch("setStatus", [todo, !todo.completed])
+		},
+		focus: function(vnode: Mithril.VnodeDOM<any, any>, todo: any) {
+			if (todo === state.editing && vnode.dom !== document.activeElement) {
+				(<HTMLInputElement>vnode.dom).value = todo.title
+				(<HTMLInputElement>vnode.dom).focus()
+				(<HTMLInputElement>vnode.dom).selectionStart = (<HTMLInputElement>vnode.dom).selectionEnd = todo.title.length
+			}
+		},
+		save: function(e: KeyboardEvent) {
+			if (e.keyCode === 13 || e.type === "blur") state.dispatch("update", [(<HTMLInputElement>e.target).value])
+			else if (e.keyCode === 27) state.dispatch("reset")
+		},
+		oninit: state.computed,
+		onbeforeupdate: state.computed,
+		view: function(vnode) {
+			var ui = vnode.state
+			return [
+				m("header.header", [
+					m("h1", "todos"),
+					m("input#new-todo[placeholder='What needs to be done?'][autofocus]", {onkeypress: ui.add}),
+				]),
+				m("section#main", {style: {display: state.todos.length > 0 ? "" : "none"}}, [
+					m("input#toggle-all[type='checkbox']", {checked: state.remaining === 0, onclick: ui.toggleAll}),
+					m("label[for='toggle-all']", {onclick: ui.toggleAll}, "Mark all as complete"),
+					m("ul#todo-list", [
+						state.todosByStatus.map(function(todo: any) {
+							return m("li", {class: (todo.completed ? "completed" : "") + " " + (todo === state.editing ? "editing" : "")}, [
+								m(".view", [
+									m("input.toggle[type='checkbox']", {checked: todo.completed, onclick: function() {ui.toggle(todo)}}),
+									m("label", {ondblclick: function() {state.dispatch("edit", [todo])}}, todo.title),
+									m("button.destroy", {onclick: function() {state.dispatch("destroy", [todo])}}),
+								]),
+								m("input.edit", {onupdate: function(vnode: Mithril.VnodeDOM<any, any>) {ui.focus(vnode, todo)}, onkeypress: ui.save, onblur: ui.save})
+							])
+						}),
+					]),
+				]),
+				state.todos.length ? m("footer#footer", [
+					m("span#todo-count", [
+						m("strong", state.remaining),
+						state.remaining === 1 ? " item left" : " items left",
+					]),
+					m("ul#filters", [
+						m("li", m("a[href='/']", {oncreate: m.route.link, class: state.showing === "" ? "selected" : ""}, "All")),
+						m("li", m("a[href='/active']", {oncreate: m.route.link, class: state.showing === "active" ? "selected" : ""}, "Active")),
+						m("li", m("a[href='/completed']", {oncreate: m.route.link, class: state.showing === "completed" ? "selected" : ""}, "Completed")),
+					]),
+					m("button#clear-completed", {onclick: function() {state.dispatch("clear")}}, "Clear completed"),
+				]) : null,
+			]
+		}
+	}
+
+	m.route(document.getElementById("todoapp")!, "/", {
+		"/": Todos,
+		"/:status": Todos,
+	})
+
+})

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "strictNullChecks": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "../mithril.d.ts",
+    "test-typings.ts"
+  ]
+}


### PR DESCRIPTION
* Added type checked m(Component, Attrs) def.
* Added Comp as better type checked alternative to Component.
* Refactored VnodeDOM into Vnode.
  This was overly limiting. It prevented use like this:
```TS
export const Foo: Mithril.Component<{}, {}> = {
	view(v) {
		return (
			m('button', {
				'type': 'button',
				'onclick': () => {
					jQuery(v.dom).trigger('close')
				}
			},
				'OK'
			)
		)
	}
}
```
* Simplified various types into ComponentTypes.
* Renamed A, S => Attrs, State
* Minor fixes.
* Added missing bits.
* Added comments.
* Formatted.
* Added tests.