### PR TITLE
Docs auto-push to gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ cache:
   directories:
   - node_modules
 
-# Custom install step so the travis scripts don't need to be in package.json
+# Custom install step so the travis-only stuff doesn't need to be in package.json
 install:
 - npm install
-- npm install @alrra/travis-scripts@^3.0.1
+- npm install @alrra/travis-scripts@^3.0.1 gh-pages@^0.12.0
 
 # Bundle before running tests so the bundle is always up-to-date
 before_script: npm run build
@@ -21,37 +21,43 @@ before_script: npm run build
 # This is the default, but leaving so it is obvious
 # script: npm test
 
-# After a successful build create bundles & commit back to the repo
+# After a successful build commit changes back to repo
 after_success:
   - |
+    # Set up SSH environment
+    $(npm bin)/set-up-ssh \
+      --key "$encrypted_8b86e0359d64_key" \
+      --iv "$encrypted_8b86e0359d64_iv" \
+      --path-encrypted-key "./.deploy.enc"
+
+    # Commit bundle changes generated in before_script step
+    # --commands is a weird no-op but required for commit-changes to run
+    # --branch arg is to ensure this only runs against the `next` branch
+    $(npm bin)/commit-changes \
+      --commands "echo committing" \
+      --commit-message "Bundled output for commit $TRAVIS_COMMIT [skip ci]" \
+      --branch "next"
     
-    # Only want to commit when building a push on whatever $BRANCH is
+    # Only want to commit docs when building pushes on master &
+    # this doesn't have the built-in branch protection likt commit-changes
     if [ "$TRAVIS_EVENT_TYPE" == "push" ] && \
-       [ "$TRAVIS_BRANCH" == "$BRANCH" ] && \
-       [ "$TRAVIS_REPO_SLUG" == "$REPO" ]
+       [ "$TRAVIS_BRANCH" == "master" ] && \
+       [ "$TRAVIS_REPO_SLUG" == "lhorie/mithril.js" ]
     then
-      # Set up SSH environment
-      $(npm bin)/set-up-ssh \
-        --key "$encrypted_8b86e0359d64_key" \
-        --iv "$encrypted_8b86e0359d64_iv" \
-        --path-encrypted-key "./.deploy.enc"
+      # Generate docs
+      $(npm-bin) run gendocs
       
-      # Commit changes (if there were any) from running build earlier
-      $(npm bin)/commit-changes \
-        --commands "echo committing" \
-        --commit-message "Bundled output for commit $TRAVIS_COMMIT [skip ci]" \
-        --branch "$BRANCH"
+      # Commit docs to gh-pages branch
+      # Using --add to ensure that archived versions aren't lost
+      # Using --repo to force it to go over SSH so the saved keys are used (tschaub/gh-pages#160)
+      $(npm bin)/gh-pages --dist ./dist --add --repo "git@github.com:lhorie/mithril.js.git"
     else
-      echo "Not submitting build artifacts"
+      echo "Not submitting documentation updates"
     fi
-    
+
 # Environment configuration
 env:
   global:
-    # Restrict the branch this will activate on
-    - BRANCH=next
-    - REPO=lhorie/mithril.js
-    
     # Set up GH_USER_EMAIL & GH_USER_NAME env variables used by travis-scripts package
     - secure: Xvqvm3+PvJu/rs3jl/NNn0RWLkkLkIoPHiL0GCfVRaywgjCYVN02g54NVvIDaOfybqPmu9E6PJFVs92vhF34NMFQHf4EWskynusIGV271R2BV0i+OJBfLMuLgiwm6zRn7/Zw4JvWIUGEwcnlz0qxbqdHsS0SOR3fIkFzePickW0=
     - secure: Rf/ldEO9d4vItJhe6EmqWpFAyCARzoCb422nHnjr1hYJknnwIXpgyZ1C/7On/9o7rWPPf+8WcHC/rgjK2rthKCldzdG5I60LfWSNzap9lk3Aa4TpSCoDBuEp7JVvDr5tc3rKnBXVT71hOay7RSx1StWzXiJs9mjaeVMJzYzRT78=

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+mithril.js.org

--- a/docs/generate.js
+++ b/docs/generate.js
@@ -3,13 +3,13 @@ var path = require("path")
 var marked = require("marked")
 var layout = fs.readFileSync("./docs/layout.html", "utf-8")
 var version = JSON.parse(fs.readFileSync("./package.json", "utf-8")).version
-try {fs.mkdirSync("../mithril")} catch (e) {}
-try {fs.mkdirSync("../mithril/archive")} catch (e) {}
-try {fs.mkdirSync("../mithril/archive/v" + version)} catch (e) {}
-try {fs.mkdirSync("../mithril/archive/v" + version + "/lib")} catch (e) {}
-try {fs.mkdirSync("../mithril/archive/v" + version + "/lib/prism")} catch (e) {}
-try {fs.mkdirSync("../mithril/lib")} catch (e) {}
-try {fs.mkdirSync("../mithril/lib/prism")} catch (e) {}
+try {fs.mkdirSync("./dist")} catch (e) {}
+try {fs.mkdirSync("./dist/archive")} catch (e) {}
+try {fs.mkdirSync("./dist/archive/v" + version)} catch (e) {}
+try {fs.mkdirSync("./dist/archive/v" + version + "/lib")} catch (e) {}
+try {fs.mkdirSync("./dist/archive/v" + version + "/lib/prism")} catch (e) {}
+try {fs.mkdirSync("./dist/lib")} catch (e) {}
+try {fs.mkdirSync("./dist/lib/prism")} catch (e) {}
 
 var guides = fs.readFileSync("docs/guides.md", "utf-8")
 var methods = fs.readFileSync("docs/methods.md", "utf-8")
@@ -55,12 +55,12 @@ function generate(pathname) {
 				.replace(/<h(.) id="([^"]+?)">(.+?)<\/h.>/gim, function(match, n, id, text) { // fix anchors
 					return "<h" + n + " id=\"" + text.toLowerCase().replace(/<(\/?)code>/g, "").replace(/<a.*?>.+?<\/a>/g, "").replace(/\.|\[|\]|&quot;|\/|\(|\)/g, "").replace(/\s/g, "-") + "\">" + text + "</h" + n + ">"
 				})
-			fs.writeFileSync("../mithril/archive/v" + version + "/" + outputFilename.replace(/^docs\//, ""), html, "utf-8")
-			fs.writeFileSync("../mithril/" + outputFilename.replace(/^docs\//, ""), html, "utf-8")
+			fs.writeFileSync("./dist/archive/v" + version + "/" + outputFilename.replace(/^docs\//, ""), html, "utf-8")
+			fs.writeFileSync("./dist/" + outputFilename.replace(/^docs\//, ""), html, "utf-8")
 		}
 		else if (!pathname.match(/lint|generate/)) {
-			fs.writeFileSync("../mithril/archive/v" + version + "/" + pathname.replace(/^docs\//, ""), fs.readFileSync(pathname, "utf-8"), "utf-8")
-			fs.writeFileSync("../mithril/" + pathname.replace(/^docs\//, ""), fs.readFileSync(pathname, "utf-8"), "utf-8")
+			fs.writeFileSync("./dist/archive/v" + version + "/" + pathname.replace(/^docs\//, ""), fs.readFileSync(pathname, "utf-8"), "utf-8")
+			fs.writeFileSync("./dist/" + pathname.replace(/^docs\//, ""), fs.readFileSync(pathname, "utf-8"), "utf-8")
 		}
 	}
 }


### PR DESCRIPTION
This modifies the existing travis script and changes the flow some so that docs will generate & auto push to the `gh-pages` branch when builds succeed on `master`. 

Was going to use `travis-scripts/update-branch` since it would do this a bit more cleanly but it has no option to preserve files on the target branch which we need for archived versions. So `gh-pages` and some flopping around it is.

**TODO once merged**

- [ ] Verify that `gh-pages` branch looks correct
- [ ] Copy archived versions from lhorie/mithril into the correct location in the `gh-pages` branch
- [ ] Set up Github Pages to use `gh-pages` branch (Only @lhorie can change repo settings)
- [ ] Tweak `mithril.js.org` to point to Github pages (I don't know how to do that)
- [ ] Rejoice at never manually pushing site updates again

**Caveat** I would love to have docs changes to `next` auto-generate docs for another site, something like mithril-next.js.org, but that doesn't seem easy currently. Closest I can get so far is to spend some time figuring out how to get it to build changes on `next` into some sort of `./next` folder in the `gh-pages` branch.

@lhorie verbally (textually?) approved this work [in gitter](https://gitter.im/lhorie/mithril.js?at=58bf3497e961e53c7fb33009)