### PR TITLE
Let `render()` create the state rather than `vnode()`

### DIFF
--- a/docs/vnodes.md
+++ b/docs/vnodes.md
@@ -73,8 +73,10 @@ Property   | Type                             | Description
 `text`     | `(String|Number|Boolean)?`       | This is used instead of `children` if a vnode contains a text node as its only child. This is done for performance reasons. Component vnodes never use the `text` property even if they have a text node as their only child.
 `dom`      | `Element?`                       | Points to the element that corresponds to the vnode. This property is `undefined` in the `oninit` lifecycle method. In fragments and trusted HTML vnodes, `dom` points to the first element in the range.
 `domSize`  | `Number?`                        | This is only set in fragment and trusted HTML vnodes, and it's `undefined` in all other vnode types. It defines the number of DOM elements that the vnode represents (starting from the element referenced by the `dom` property).
-`state`    | `Object`                         | An object that is persisted between redraws. In component vnodes, `state` is a shallow clone of the component object.
+`state`    | `Object`?                        | An object that is persisted between redraws. It is provided by the core engine when needed. In component vnodes, the `state` inherits prototypically from the component object/class.
 `events`   | `Object?`                        | An object that is persisted between redraws and that stores event handlers so that they can be removed using the DOM API. The `events` property is `undefined` if there are no event handlers defined. This property is only used internally by Mithril, do not use it.
+
+
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -21,6 +21,7 @@ module.exports = function($window) {
 	function createNode(parent, vnode, hooks, ns, nextSibling) {
 		var tag = vnode.tag
 		if (typeof tag === "string") {
+			vnode.state = {}
 			if (vnode.attrs != null) initLifecycle(vnode.attrs, vnode, hooks)
 			switch (tag) {
 				case "#": return createText(parent, vnode, nextSibling)
@@ -238,7 +239,10 @@ module.exports = function($window) {
 			if (!recycling && shouldNotUpdate(vnode, old)) return
 			if (typeof oldTag === "string") {
 				if (vnode.attrs != null) {
-					if (recycling) initLifecycle(vnode.attrs, vnode, hooks)
+					if (recycling) {
+						vnode.state = {}
+						initLifecycle(vnode.attrs, vnode, hooks)
+					}
 					else updateLifecycle(vnode.attrs, vnode, hooks)
 				}
 				switch (oldTag) {

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,5 +1,5 @@
 function Vnode(tag, key, attrs, children, text, dom) {
-	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: {}, events: undefined, instance: undefined, skip: false}
+	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: undefined, events: undefined, instance: undefined, skip: false}
 }
 Vnode.normalize = function(node) {
 	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)


### PR DESCRIPTION
This is the simple proposal described in #1694.

`vnode.state` is not defined by `Vnode` anymore, but by `createNode`, and `updateNode` for recycled components (this fixes a bug in the latter case where the old state would be recycled for non-component nodes).