### PR TITLE
Fixes component usage in jsx.md.

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -45,8 +45,8 @@ var link = <a href={url}>{greeting + "!"}</a>
 Components can be used by using a convention of uppercasing the first letter of the component name:
 
 ```jsx
-m.mount(document.body, <MyComponent />)
-// equivalent to m.mount(document.body, m(MyComponent))
+m.render(document.body, <MyComponent />)
+// equivalent to m.render(document.body, m(MyComponent))
 ```
 
 ---


### PR DESCRIPTION
Updates `m.mount(document.body, <MyComponent />)` to `m.render(document.body, <MyComponent />)`.

After consuming a component using `m(component)`, you can't *mount* it to element but you can *render*.