### PR TITLE
Component instances are always fragments - fixes #1713

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -127,7 +127,7 @@ module.exports = function($window) {
 	function createComponent(parent, vnode, hooks, ns, nextSibling) {
 		initComponent(vnode, hooks)
 		if (vnode.instance != null) {
-			if (vnode.instance[0] === vnode) throw Error("A view cannot return the vnode it received as arguments")
+			if (vnode.instance.children[0] === vnode) throw Error("A view cannot return the vnode it received as arguments")
 			var element = createNode(parent, vnode.instance, hooks, ns, nextSibling)
 			vnode.dom = vnode.instance.dom
 			vnode.domSize = vnode.dom != null ? vnode.instance.domSize : 0

--- a/render/render.js
+++ b/render/render.js
@@ -119,13 +119,15 @@ module.exports = function($window) {
 
 		if (vnode.attrs != null) initLifecycle(vnode.attrs, vnode, hooks)
 		initLifecycle(vnode.state, vnode, hooks)
-		vnode.instance = Vnode.normalize(vnode.state.view(vnode))
+		var output = vnode.state.view(vnode)
+		if (!Array.isArray(output)) output = [output]
+		vnode.instance = Vnode.normalize(output)
 		sentinel.$$reentrantLock$$ = null
 	}
 	function createComponent(parent, vnode, hooks, ns, nextSibling) {
 		initComponent(vnode, hooks)
 		if (vnode.instance != null) {
-			if (vnode.instance === vnode) throw Error("A view cannot return the vnode it received as arguments")
+			if (vnode.instance[0] === vnode) throw Error("A view cannot return the vnode it received as arguments")
 			var element = createNode(parent, vnode.instance, hooks, ns, nextSibling)
 			vnode.dom = vnode.instance.dom
 			vnode.domSize = vnode.dom != null ? vnode.instance.domSize : 0
@@ -317,7 +319,9 @@ module.exports = function($window) {
 		if (recycling) {
 			initComponent(vnode, hooks)
 		} else {
-			vnode.instance = Vnode.normalize(vnode.state.view(vnode))
+			var output = vnode.state.view(vnode)
+			if (!Array.isArray(output)) output = [output]
+			vnode.instance = Vnode.normalize(output)
 			if (vnode.attrs != null) updateLifecycle(vnode.attrs, vnode, hooks)
 			updateLifecycle(vnode.state, vnode, hooks)
 		}


### PR DESCRIPTION
By ensuring component instances are always lists - even if the view output is a single node - `key` can be used for identification semantics universally. This also makes vnode traversal easier, since it standardizes component instance type.

There component tests for self-returning vnodes are failing for reasons I don't understand.