### PR TITLE
added test for stream.end.map

### DIFF
--- a/stream/tests/test-stream.js
+++ b/stream/tests/test-stream.js
@@ -263,6 +263,15 @@ o.spec("stream", function() {
 
 			o(doubled()).equals(4)
 		})
+		o("end stream can be mapped to", function() {
+		    var stream = Stream()
+		    var spy = o.spy()
+
+		    stream.end.map(spy)
+		    stream.end(true)
+
+		    o(spy.callCount).equals(1)
+		})		
 	})
 	o.spec("valueOf", function() {
 		o("works", function() {


### PR DESCRIPTION
Tests for issue #1736

Any maps set to the end stream do not get called.
In fact, for some reason adding a map to and end stream throws an error:

```
Cannot read property '_state' of undefined
    at updateDependency (/Users/eladzlot/www/mithril.js/stream/stream.js:46:20)
```