### PR TITLE
Fix stream end map

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 .vscode
-/node_modules
-/examples
+/coverage
 /docs/lib
+/examples
 /mithril.js
 /mithril.min.js
+/node_modules

--- a/stream/tests/test-stream.js
+++ b/stream/tests/test-stream.js
@@ -264,14 +264,17 @@ o.spec("stream", function() {
 			o(doubled()).equals(4)
 		})
 		o("end stream can be mapped to", function() {
-		    var stream = Stream()
-		    var spy = o.spy()
+			var stream = Stream()
+			var spy = o.spy()
 
-		    stream.end.map(spy)
-		    stream.end(true)
+			stream.end.map(spy)
 
-		    o(spy.callCount).equals(1)
-		})		
+			o(spy.callCount).equals(0)
+
+			stream.end(true)
+
+			o(spy.callCount).equals(1)
+		})
 	})
 	o.spec("valueOf", function() {
 		o("works", function() {

--- a/stream/tests/test-stream.js
+++ b/stream/tests/test-stream.js
@@ -263,6 +263,15 @@ o.spec("stream", function() {
 
 			o(doubled()).equals(4)
 		})
+		o("end stream can be mapped to", function() {
+		    var stream = Stream()
+		    var spy = o.spy()
+
+		    stream.end.map(spy)
+		    stream.end(true)
+
+		    o(spy.callCount).equals(1)
+		})		
 	})
 	o.spec("valueOf", function() {
 		o("works", function() {


### PR DESCRIPTION
This builds on top of #1737 to fix #1736.

Oddly enough, my local git version is convinced that `stream.stream.js` is a binary file. Thankfully the diff shows fine here.