### PR TITLE
Automate github release pages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,8 +61,8 @@ module.exports = {
         "id-length": "off",
         "id-match": "error",
         "indent": [
-            "warn", 
-            "tab", 
+            "warn",
+            "tab",
             {
                 "outerIIFEBody": 0,
                 "SwitchCase": 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,20 +64,20 @@ env:
 
 # Deploy to npm and github pages on tagged commits that successfully build
 deploy:
-  skip_cleanup: true
-  
   - provider: releases
     api_key:
       secure: PauFuz+pn7oRpHn2JTl4k3+iWjOofyBYBvavPQVNdXgKws9mGj0i2n5k2oIDU09VD7NeyEkwP6tdLCUFNaR8uwTJH/TBXMZE95oxUEaliFreA0nOiI3WkG4NCW0GwUoIIn1yL14y6+9oEBinWUia8DIn9kZNS11DNDgQpIPnoQQ=
     file:
       - "mithril.js"
       - "mithril.min.js"
+    skip_cleanup: true
     on:
       tags: true
       repo: lhorie/mithril.js
       branch: master
   
   - provider: npm
+    skip_cleanup: true
     email: npm@patcavit.com
     api_key:
       secure: ADElvD1oxn9GfEG7dDOggX96b36A/cGEybovAc0221CCKzv5kWCavMrtxneiJYI6N/n24abSlbM90vMfU84FEzH0Ev28dGVokRP4ad6VRkISszKlYVEP8Lds4QxfKh78jZlUxmxM0B3vmQ1kYJbTBqp3ICtaJ5ptEQHWhrLtxnc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ after_success:
       --branch "next"
     
     # Only want to commit docs when building pushes on master &
-    # this doesn't have the built-in branch protection likt commit-changes
+    # this doesn't have the built-in branch protection like commit-changes
     if [ "$TRAVIS_EVENT_TYPE" == "push" ] && \
        [ "$TRAVIS_BRANCH" == "master" ] && \
        [ "$TRAVIS_REPO_SLUG" == "lhorie/mithril.js" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ deploy:
     on:
       tags: true
       repo: lhorie/mithril.js
+      branch: master
   
   - provider: npm
     email: npm@patcavit.com
@@ -83,3 +84,4 @@ deploy:
     on:
       tags: true
       repo: lhorie/mithril.js
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,24 @@ env:
     - secure: Xvqvm3+PvJu/rs3jl/NNn0RWLkkLkIoPHiL0GCfVRaywgjCYVN02g54NVvIDaOfybqPmu9E6PJFVs92vhF34NMFQHf4EWskynusIGV271R2BV0i+OJBfLMuLgiwm6zRn7/Zw4JvWIUGEwcnlz0qxbqdHsS0SOR3fIkFzePickW0=
     - secure: Rf/ldEO9d4vItJhe6EmqWpFAyCARzoCb422nHnjr1hYJknnwIXpgyZ1C/7On/9o7rWPPf+8WcHC/rgjK2rthKCldzdG5I60LfWSNzap9lk3Aa4TpSCoDBuEp7JVvDr5tc3rKnBXVT71hOay7RSx1StWzXiJs9mjaeVMJzYzRT78=
 
-# Deploy to npm on tagged commits that successfully build
+# Deploy to npm and github pages on tagged commits that successfully build
 deploy:
-  provider: npm
-  email: npm@patcavit.com
   skip_cleanup: true
-  api_key:
-    secure: ADElvD1oxn9GfEG7dDOggX96b36A/cGEybovAc0221CCKzv5kWCavMrtxneiJYI6N/n24abSlbM90vMfU84FEzH0Ev28dGVokRP4ad6VRkISszKlYVEP8Lds4QxfKh78jZlUxmxM0B3vmQ1kYJbTBqp3ICtaJ5ptEQHWhrLtxnc=
-  on:
-    tags: true
-    repo: lhorie/mithril.js
+  
+  - provider: releases
+    api_key:
+      secure: PauFuz+pn7oRpHn2JTl4k3+iWjOofyBYBvavPQVNdXgKws9mGj0i2n5k2oIDU09VD7NeyEkwP6tdLCUFNaR8uwTJH/TBXMZE95oxUEaliFreA0nOiI3WkG4NCW0GwUoIIn1yL14y6+9oEBinWUia8DIn9kZNS11DNDgQpIPnoQQ=
+    file:
+      - "mithril.js"
+      - "mithril.min.js"
+    on:
+      tags: true
+      repo: lhorie/mithril.js
+  
+  - provider: npm
+    email: npm@patcavit.com
+    api_key:
+      secure: ADElvD1oxn9GfEG7dDOggX96b36A/cGEybovAc0221CCKzv5kWCavMrtxneiJYI6N/n24abSlbM90vMfU84FEzH0Ev28dGVokRP4ad6VRkISszKlYVEP8Lds4QxfKh78jZlUxmxM0B3vmQ1kYJbTBqp3ICtaJ5ptEQHWhrLtxnc=
+    on:
+      tags: true
+      repo: lhorie/mithril.js

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,10 +8,10 @@ Releasing new builds of mithril is mostly automated via `npm version`
 
 All further steps are automated and run as follows:
 
-2. Tests are run
-3. Linting is run (but doesn't fail build)
-4. Version number in package.json is incremented
-5. New bundles are generated using updated version
+2. New bundles are generated using updated version
+3. Tests are run
+4. Linting is run (but doesn't fail build)
+5. Version number in package.json is incremented
 6. `git add` called on bundle output
 7. `package.json` and updated bundles are committed to git
 8. previous commit is tagged using new version number
@@ -27,7 +27,9 @@ All further steps are automated and run as follows:
 
 ## Publishing a GitHub release
 
-**TODO**
+Happens automatically as part of the [Publishing to NPM](#publishing-to-npm) process described above.
+
+Does require a manual description to be added though, as the auto-generated one isn't very interesting.
 
 ## Updating `docs/change-log.md`
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test": "node ospec/bin/ospec",
     "posttest": "npm run lint || true",
     "cover": "istanbul cover --print both ospec/bin/ospec",
-    "preversion": "npm run test",
-    "version": "npm run build && npm run gendocs && git add mithril.js mithril.min.js",
+    "preversion": "npm run build && npm run test",
+    "version": "npm run gendocs && git add mithril.js mithril.min.js",
     "postversion": "git push --follow-tags"
   },
   "devDependencies": {


### PR DESCRIPTION
They won't have an amazing description or anything, but every time we push a tagged commit to `master` it'll create a Github release.

:warning: **This is really difficult to test outside of the main repo, so there may be some bugs** :warning:

Once it lands I may need to do some futzing to get it fixed up when it's time for the next release.