### PR TITLE
Fix some quotes

### DIFF
--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -17,89 +17,89 @@ o.spec("hyperscript", function() {
 			o(vnode.tag).equals("a")
 		})
 		o("v1.0.1 bug-for-bug regression suite", function(){
-			o(m('a', {
+			o(m("a", {
 				class: null
 			}).attrs).deepEquals({
 				class: undefined,
 				className: null
 			})
-			o(m('a', {
+			o(m("a", {
 				class: undefined
 			}).attrs).deepEquals({
 				class: undefined,
 			})
-			o(m('a', {
+			o(m("a", {
 				class: false
 			}).attrs).deepEquals({
 				class: undefined,
 				className: false
 			})
-			o(m('a', {
+			o(m("a", {
 				class: true
 			}).attrs).deepEquals({
 				class: undefined,
 				className: true
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				class: null
 			}).attrs).deepEquals({
 				class: undefined,
 				className: "x null"
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				class: undefined
 			}).attrs).deepEquals({
 				class: undefined,
 				className: "x"
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				class: false
 			}).attrs).deepEquals({
 				class: undefined,
 				className: "x false"
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				class: true
 			}).attrs).deepEquals({
 				class: undefined,
 				className: "x true"
 			})
-			o(m('a', {
+			o(m("a", {
 				className: null
 			}).attrs).deepEquals({
 				className: null
 			})
-			o(m('a', {
+			o(m("a", {
 				className: undefined
 			}).attrs).deepEquals({
 				className: undefined
 			})
-			o(m('a', {
+			o(m("a", {
 				className: false
 			}).attrs).deepEquals({
 				className: false
 			})
-			o(m('a', {
+			o(m("a", {
 				className: true
 			}).attrs).deepEquals({
 				className: true
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				className: null
 			}).attrs).deepEquals({
 				className: "x"
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				className: undefined
 			}).attrs).deepEquals({
 				className: "x"
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				className: false
 			}).attrs).deepEquals({
 				className: "x"
 			})
-			o(m('a.x', {
+			o(m("a.x", {
 				className: true
 			}).attrs).deepEquals({
 				className: "x true"


### PR DESCRIPTION
So `npm lint` passes again.