### PR TITLE
Add codepen examples for tutorial

### DIFF
--- a/docs/generate.js
+++ b/docs/generate.js
@@ -27,6 +27,7 @@ function generate(pathname) {
 		if (pathname.match(/\.md$/)) {
 			var outputFilename = pathname.replace(/\.md$/, ".html")
 			var markdown = fs.readFileSync(pathname, "utf-8")
+			var anchors = {}
 			var fixed = markdown
 				.replace(/`((?:\S| -> |, )+)(\|)(\S+)`/gim, function(match, a, b, c) { // fix pipes in code tags
 					return "<code>" + (a + b + c).replace(/\|/g, "&#124;") + "</code>"
@@ -52,6 +53,12 @@ function generate(pathname) {
 				.replace(/\[body\]/, markedHtml)
 				.replace(/<h(.) id="([^"]+?)">(.+?)<\/h.>/gim, function(match, n, id, text) { // fix anchors
 					var anchor = text.toLowerCase().replace(/<(\/?)code>/g, "").replace(/<a.*?>.+?<\/a>/g, "").replace(/\.|\[|\]|&quot;|\/|\(|\)/g, "").replace(/\s/g, "-");
+
+					if(anchor in anchors) {
+						anchor += ++anchors[anchor]
+					} else {
+						anchors[anchor] = 0;
+					}
 
 					return `<h${n} id="${anchor}"><a href="#${anchor}">${text}</a></h${n}>`;
 				})

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ Mithril supports browsers all the way back to IE9, no polyfills required.
 
 ### Getting started
 
-The easiest way to try out Mithril is to include it from a CDN, and follow this tutorial. It'll cover the majority of the API surface (including routing and XHR) but it'll only take 10 minutes.
+An easy way to try out Mithril is to include it from a CDN and follow this tutorial. It'll cover the majority of the API surface (including routing and XHR) but it'll only take 10 minutes.
 
 Let's create an HTML file to follow along:
 
@@ -64,6 +64,11 @@ Let's create an HTML file to follow along:
 	</script>
 </body>
 ```
+
+To make things simpler you can fork this pen which already has the latest version of mithril loaded.
+
+<p data-height="265" data-theme-id="light" data-slug-hash="XRrXVR" data-default-tab="js,result" data-user="tivac" data-embed-version="2" data-pen-title="Mithril Scaffold" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/tivac/pen/XRrXVR/">Mithril Scaffold</a> by Pat Cavit (<a href="http://codepen.io/tivac">@tivac</a>) on <a href="http://codepen.io">CodePen</a>.</p>
+<script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,11 @@ m.render(root, "My first app")
 
 As you can see, you use the same code to both create and update HTML. Mithril automatically figures out the most efficient way of updating the text, rather than blindly recreating it from scratch.
 
+#### Live Example
+
+<p data-height="265" data-theme-id="light" data-slug-hash="KmPdOO" data-default-tab="js,result" data-user="tivac" data-embed-version="2" data-pen-title="Mithril Hello World" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/tivac/pen/KmPdOO/">Mithril Hello World</a> by Pat Cavit (<a href="http://codepen.io/tivac">@tivac</a>) on <a href="http://codepen.io">CodePen</a>.</p>
+<script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
+
 ---
 
 ### DOM elements
@@ -118,6 +123,11 @@ m("main", [
 	m("button", "A button"),
 ])
 ```
+
+#### Live Example
+
+<p data-height="275" data-theme-id="light" data-slug-hash="gWYade" data-default-tab="js,result" data-user="tivac" data-embed-version="2" data-pen-title="Simple Mithril Example" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/tivac/pen/gWYade/">Simple Mithril Example</a> by Pat Cavit (<a href="http://codepen.io/tivac">@tivac</a>) on <a href="http://codepen.io">CodePen</a>.</p>
+<script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
 
 Note: If you prefer `<html>` syntax, [it's possible to use it via a Babel plugin](jsx.md).
 
@@ -185,6 +195,11 @@ You can now update the label of the button by clicking the button. Since we used
 
 If you're wondering about performance, it turns out Mithril is very fast at rendering updates, because it only touches the parts of the DOM it absolutely needs to. So in our example above, when you click the button, the text in it is the only part of the DOM Mithril actually updates.
 
+#### Live Example
+
+<p data-height="300" data-theme-id="light" data-slug-hash="rmBOQV" data-default-tab="js,result" data-user="tivac" data-embed-version="2" data-pen-title="Mithril Component Example" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/tivac/pen/rmBOQV/">Mithril Component Example</a> by Pat Cavit (<a href="http://codepen.io/tivac">@tivac</a>) on <a href="http://codepen.io">CodePen</a>.</p>
+<script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
+
 ---
 
 ### Routing
@@ -217,6 +232,11 @@ The `m.route` function still has the same auto-redrawing functionality that `m.m
 The `"/splash"` right after `root` means that's the default route, i.e. if the hashbang in the URL doesn't point to one of the defined routes (`/splash` and `/hello`, in our case), then Mithril redirects to the default route. So if you open the page in a browser and your URL is `http://localhost`, then you get redirected to `http://localhost/#!/splash`.
 
 Also, as you would expect, clicking on the link on the splash page takes you to the click counter screen we created earlier. Notice that now your URL will point to `http://localhost/#!/hello`. You can navigate back and forth to the splash page using the browser's back and next button.
+
+#### Live Example
+
+<p data-height="300" data-theme-id="light" data-slug-hash="qmWOvr" data-default-tab="js,result" data-user="tivac" data-embed-version="2" data-pen-title="Mithril Routing Example" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/tivac/pen/qmWOvr/">Mithril Routing Example</a> by Pat Cavit (<a href="http://codepen.io/tivac">@tivac</a>) on <a href="http://codepen.io">CodePen</a>.</p>
+<script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
 
 ---
 
@@ -259,6 +279,11 @@ var Hello = {
 ```
 
 Clicking the button should now update the count.
+
+#### Live Example
+
+<p data-height="265" data-theme-id="light" data-slug-hash="WjeQBW" data-default-tab="js,result" data-user="tivac" data-embed-version="2" data-pen-title="Mithril XHR Example" data-preview="true" class="codepen">See the Pen <a href="https://codepen.io/tivac/pen/WjeQBW/">Mithril XHR Example</a> by Pat Cavit (<a href="http://codepen.io/tivac">@tivac</a>) on <a href="http://codepen.io">CodePen</a>.</p>
+<script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
 
 ---
 


### PR DESCRIPTION
We keep talking about it, so I went ahead and gave it a shot.

I used codepen because JsBin requires a Pro account to embed HTTPS bins, which is a bummer. The default codepen styling works ok though w/ the site aesthetic IMO.

I made them click-to-load in the interest of not slowing the site down any more than necessary. Here's an example of the embed before clicking

![image](https://cloud.githubusercontent.com/assets/49545/24895611/e2e1aef0-1e80-11e7-8c16-d2ccebd367ad.png)

and then after

![image](https://cloud.githubusercontent.com/assets/49545/24895646/036fe678-1e81-11e7-840e-564711f37723.png)

The pens aren't editable on the page (because that requires a Pro account) but even seeing them up & working seems pretty worthwhile to me.

Thoughts? Should I take this further? I think the homepage is probably the biggest bang for our buck in terms of showing live examples so limited it to that page, but they're simple enough to add to other pages if it's worthwhile.
